### PR TITLE
fix: build failures in Arch

### DIFF
--- a/frame/cgraphicsview.h
+++ b/frame/cgraphicsview.h
@@ -20,6 +20,7 @@
 #define CGRAPHICSVIEW_H
 #include "drawshape/csizehandlerect.h"
 #include "widgets/cmenu.h"
+#include <QFileDevice>
 #include <DGraphicsView>
 
 DWIDGET_USE_NAMESPACE


### PR DESCRIPTION
Fixes the following build failures:

```
In file included from widgets/bordercolorbutton.cpp:27:
./frame/cgraphicsview.h:250:31: error: ‘QFileDevice’ has not been declared
  250 |                               QFileDevice::FileError error,
      |                               ^~~~~~~~~~~
./frame/cgraphicsview.h:250:54: error: expected ‘,’ or ‘...’ before ‘error’
  250 |                               QFileDevice::FileError error,
      |                                                      ^~~~~
widgets/bordercolorbutton.cpp: In member function ‘void BorderColorButton::setButtonText(QString)’:
widgets/bordercolorbutton.cpp:153:41: warning: ‘int QFontMetrics::width(const QString&, int) const’ is deprecated: Use QFontMetrics::horizontalAdvance [-Wdeprecated-declarations]
  153 |     m_textWidth = fontMetrics.width(text);
      |                                         ^
In file included from /usr/include/qt/QtWidgets/qwidget.h:50,
                 from /usr/include/qt/QtWidgets/qabstractbutton.h:46,
                 from /usr/include/qt/QtWidgets/qpushbutton.h:44,
                 from /usr/include/qt/QtWidgets/QPushButton:1,
                 from /usr/include/libdtk-5.2.0/DWidget/DPushButton:2,
                 from widgets/bordercolorbutton.h:22,
                 from widgets/bordercolorbutton.cpp:19:
/usr/include/qt/QtGui/qfontmetrics.h:106:9: note: declared here
  106 |     int width(const QString &, int len = -1) const;
      |         ^~~~~
In file included from widgets/csidewidthwidget.cpp:25:
./frame/cgraphicsview.h:250:31: error: ‘QFileDevice’ has not been declared
  250 |                               QFileDevice::FileError error,
      |                               ^~~~~~~~~~~
./frame/cgraphicsview.h:250:54: error: expected ‘,’ or ‘...’ before ‘error’
  250 |                               QFileDevice::FileError error,
      |                                                      ^~~~~
```