### PR TITLE
fix: build failures in Arch

### DIFF
--- a/widgets/ciconbutton.cpp
+++ b/widgets/ciconbutton.cpp
@@ -22,6 +22,7 @@
 #include "frame/cviewmanagement.h"
 
 #include <QPainter>
+#include <QMouseEvent>
 #include <QDebug>
 
 #include <DPalette>


### PR DESCRIPTION
Fixes the following build failures:

```
widgets/ciconbutton.cpp: In member function ‘virtual void CIconButton::mouseReleaseEvent(QMouseEvent*)’:
widgets/ciconbutton.cpp:106:10: error: invalid use of incomplete type ‘class QMouseEvent’
  106 |     if (e->button() == Qt::LeftButton) {
      |          ^~
```