### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-draw.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-draw.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-draw
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-draw
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-draw.spec"

--- a/rpm/deepin-draw.spec
+++ b/rpm/deepin-draw.spec
@@ -1,0 +1,53 @@
+Name:           deepin-draw
+Version:        5.8.0.66
+Release:        1%{?dist}
+Summary:        A lightweight drawing tool for Linux Deepin
+License:        GPLv3
+URL:            https://github.com/linuxdeepin/deepin-draw
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  freeimage-devel
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0.6
+BuildRequires:  pkgconfig(dtkwm)
+BuildRequires:  pkgconfig(libexif)
+BuildRequires:  pkgconfig(xcb-aux)
+BuildRequires:  pkgconfig(Qt5)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  qt5-linguist
+BuildRequires:  desktop-file-utils
+Requires:       deepin-notifications
+Requires:       deepin-qt5integration
+
+%description
+A lightweight drawing tool for Linux Deepin.
+
+%prep
+%autosetup -p1
+
+%build
+%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo
+%cmake_build
+
+%install
+%cmake_install
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+%{_datadir}/mime/packages/%{name}.xml
+%{_datadir}/dbus-1/services/com.deepin.Draw.service
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>