### PR TITLE
Fix: Missing semicolon

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -347,7 +347,7 @@ bool Application::isWaylandPlatform()
 bool Application::isTabletSystemEnvir()
 {
 #if (DTK_VERSION > DTK_VERSION_CHECK(5, 5, 0, 0))
-    return DGuiApplicationHelper::isTabletEnvironment()
+    return DGuiApplicationHelper::isTabletEnvironment();
 #else
 #ifdef ENABLE_TABLETSYSTEM
     return true;


### PR DESCRIPTION
Build was failing when `TK_VERSION > DTK_VERSION_CHECK(5, 5, 0, 0)` due to a semicolon missing.

```
 26%] Building CXX object src/CMakeFiles/deepinDrawBase.dir/application.cpp.o
~/deepin-draw/src/application.cpp: In static member function ‘static bool Application::isTabletSystemEnvir()’:
~/deepin-draw/src/application.cpp:350:56: error: expected ‘;’ before ‘}’ token
  350 |     return DGuiApplicationHelper::isTabletEnvironment()
      |                                                        ^
      |                                                        ;
......
  357 | }
      | ~                                                       
make[2]: *** [src/CMakeFiles/deepinDrawBase.dir/build.make:7509: src/CMakeFiles/deepinDrawBase.dir/application.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:117: src/CMakeFiles/deepinDrawBase.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```