### PR TITLE
fix: 修改工具栏和滑动条UI

### DIFF
--- a/src/frame/ccentralwidget.cpp
+++ b/src/frame/ccentralwidget.cpp
@@ -127,7 +127,7 @@ public:
         hLay->setSpacing(0);
 
         _leftScrollArea = new DScrollArea(_borad);
-        _leftScrollArea->setFixedWidth(68);//设置比工具栏宽10
+        _leftScrollArea->setFixedWidth(_toolManager->width());
         _leftScrollArea->setWidgetResizable(true);
         _leftScrollArea->setWidget(_toolManager);
         _leftScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);

--- a/src/frame/clefttoolbar.cpp
+++ b/src/frame/clefttoolbar.cpp
@@ -31,6 +31,7 @@ DGUI_USE_NAMESPACE
 
 const int BTN_SPACING = 12;
 bool blocked = false;
+const int TOOL_MANAGER_WIDTH = 68;
 
 DrawToolManager::DrawToolManager(DrawBoard *parent)
     : DFrame(parent), m_drawBoard(parent)
@@ -188,7 +189,7 @@ void DrawToolManager::initUI()
     this->setAutoFillBackground(true);
 
     setMinimumHeight(460);//设置最小高度保证最小化显示正常
-    setFixedWidth(58);
+    setFixedWidth(TOOL_MANAGER_WIDTH);
 
     auto mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
Description: 工具栏和滑动条宽度一致，导致空出10px颜色很突兀。修改工具栏宽度和滑动条一致

Log: 修改工具栏和滑动条UI

Bug: https://pms.uniontech.com/bug-view-156921.html