### PR TITLE
fix: 颜色选择弹窗的背景问题

### DIFF
--- a/src/frame/AttributesWidgets/ccolorpickwidget.cpp
+++ b/src/frame/AttributesWidgets/ccolorpickwidget.cpp
@@ -11,21 +11,26 @@
 //#include "toptoolbar.h"
 #include <DPlatformWindowHandle>
 #include <DWindowManagerHelper>
+const int RADIUS_VALUE = 18;
+const int ARROW_WIDTH = 40;
+const int ARROW_HEIGHT = 30;
 CColorPickWidget::CColorPickWidget(QWidget *parent)
-    : DArrowRectangle(ArrowTop, FloatWidget, parent)
+    : DArrowRectangle(ArrowTop, FloatWindow, parent)
 {
     setWgtAccesibleName(this, "ColorPickWidget");
-    this->setWindowFlag(Qt::FramelessWindowHint);
+    this->setWindowFlags(Qt::FramelessWindowHint);
     this->setWindowFlag(Qt::/*Popup*/Popup);
-    this->setAttribute(Qt::WA_TranslucentBackground, true);
-    this->setArrowWidth(18);
-    this->setArrowHeight(10);
+    this->setAttribute(Qt::WA_TranslucentBackground);
+    setRadiusArrowStyleEnable(true);
+    this->setArrowWidth(ARROW_WIDTH);
+    this->setArrowHeight(ARROW_HEIGHT);
     m_colorPanel = new ColorPanel(this);
     m_colorPanel->setFocusPolicy(Qt::NoFocus);
     this->setFocusPolicy(Qt::NoFocus);
     //this->setContent(m_colorPanel);
     this->hide();
 
+    setRadius(RADIUS_VALUE);
     //connect(m_colorPanel, &ColorPanel::colorChanged, this, &CColorPickWidget::colorChanged);
     connect(m_colorPanel, &ColorPanel::colorChanged, this, [ = ](const QColor & color, EChangedPhase phase) {
         qDebug() << "color ===== " << color << "phase = " << phase;

--- a/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+++ b/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
@@ -26,7 +26,8 @@
 #include <QGraphicsDropShadowEffect>
 
 using namespace DrawAttribution;
-
+const int X_OFFSET = 25;
+const int Y_OFFSET = -21;
 DrawAttribution::CColorSettingButton::CColorSettingButton(const QString &text,
                                                           QWidget *parent, bool autoConnect):
     CAttributeWgt(-1, parent), _text(text)
@@ -115,8 +116,8 @@ void DrawAttribution::CColorSettingButton::mousePressEvent(QMouseEvent *event)
         // colorPick->setExpandWidgetVisble(false);
 
         QPoint btnPos = mapToGlobal(QPoint(0, 0));
-        QPoint pos(btnPos.x() + 14,
-                   btnPos.y() + this->height());
+        QPoint pos(btnPos.x() + X_OFFSET,
+                   btnPos.y() + this->height() + Y_OFFSET);
 
         colorPick->show(pos.x(), pos.y());
 


### PR DESCRIPTION
Description: 颜色选择框样式为控件，其大小会受限于父类窗口大小，背景会有白色窗口。调整颜色选择框为独立窗口，并修改弹出UI样式。

Log: 颜色选择弹窗的背景问题

Bug: https://pms.uniontech.com/bug-view-156951.html