### PR TITLE
fix: x-ddf.xml文件目录整改

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,8 +156,5 @@ install(FILES ./logo/deepin-draw.svg DESTINATION ${ManIconDir})
 # install App icon
 install(FILES ./logo/deepin-draw.svg DESTINATION ${AppIconDir})
 
-# install Mimetype
-install(FILES ./service/x-ddf.xml DESTINATION ${MimeTypeDir})
-
 add_subdirectory(deepin-draw)
 

--- a/src/service/x-ddf.xml
+++ b/src/service/x-ddf.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<mime-type xmlns="http://www.freedesktop.org/standards/shared-mime-info" type="application/x-ddf">
-  <!--Created automatically by update-mime-database. DO NOT EDIT!-->
-  <comment>deepin draw files</comment>
-  <generic-icon name="deepin-draw"/>
-  <glob pattern="*.ddf" weight="80"/>
-  <glob pattern="*.DDF" weight="80"/>
-</mime-type>


### PR DESCRIPTION
Description: update-mime-database通过deepin-draw.xml自动生成x-ddf.xml，无需自己安装该文件

Log: x-ddf.xml文件目录整改