### PR TITLE
fix: 修复紧凑模式下百分比按钮显示异常

### DIFF
--- a/src/frame/toptoolbar.cpp
+++ b/src/frame/toptoolbar.cpp
@@ -85,7 +85,6 @@ void TopTilte::initComboBox()
     m_zoomMenuComboBox = new DZoomMenuComboBox(this);
     m_zoomMenuComboBox->setFont(ft);
     m_zoomMenuComboBox->setMenuFlat(false);
-    m_zoomMenuComboBox->setFixedWidth(162);
     m_zoomMenuComboBox->addItem("200%");
     m_zoomMenuComboBox->addItem("100%");
     m_zoomMenuComboBox->addItem("75%");

--- a/src/widgets/dzoommenucombobox.h
+++ b/src/widgets/dzoommenucombobox.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,112 +17,106 @@ DWIDGET_USE_NAMESPACE
 class QHBoxLayout;
 
 /*
-* @bref: DZoomMenuComboBox 该组件效果类似DComboBox下拉框效果，左右两侧各有一个伸缩比例按钮
-*/
+ * @bref: DZoomMenuComboBox 该组件效果类似DComboBox下拉框效果，左右两侧各有一个伸缩比例按钮
+ */
 
 class DZoomMenuComboBox : public DWidget
 {
     Q_OBJECT
 public:
     explicit DZoomMenuComboBox(DWidget *parent = nullptr);
+    ~DZoomMenuComboBox() override;
 
-    ~DZoomMenuComboBox();
     /*
-    * @bref: addItem 添加子选项
-    */
+     * @bref: addItem 添加子选项
+     */
     void addItem(const QString &itemText);
     void addItem(QString itemText, QIcon icon);
     void addItem(QAction *action);
 
     /*
-    * @bref: removeItem 删除子选项
-    */
+     * @bref: removeItem 删除子选项
+     */
     void removeItem(const QString &itemText);
     void removeItem(int index);
     void removeItem(QAction *action);
 
     /*
-    * @bref: setCurrentIndex 设置选中项
-    */
+     * @bref: setCurrentIndex 设置选中项
+     */
     void setCurrentIndex(int index);
-//    int getCurrentIndex() const;
 
     /*
-    * @bref: setCurrentText 设置选中项
-    */
+     * @bref: setCurrentText 设置选中项
+     */
     void setCurrentText(const QString &text);
-//    QString getCurrentText() const;
 
     /*
-    * @bref: setMenuFlat 设置flat
-    */
+     * @bref: setMenuFlat 设置flat
+     */
     void setMenuFlat(bool flat);
 
-//    /*
-//    * @bref: setArrowDirction 设置菜单箭头显示位置
-//    */
-//    void setArrowDirction(Qt::LayoutDirection dir = Qt::LayoutDirection::RightToLeft);
-
     /*
-    * @bref: setArrowICon 设置菜单图标
-    */
+     * @bref: setArrowICon 设置菜单图标
+     */
     void setArrowICon(QIcon icon);
 
     /*
-    * @bref: setItemICon 设置子菜单图标
-    * @parma: text 子菜单选项文本名字
-    * @parma: index 子菜单选项索引
-    */
+     * @bref: setItemICon 设置子菜单图标
+     * @parma: text 子菜单选项文本名字
+     * @parma: index 子菜单选项索引
+     */
     void setItemICon(const QString &text, const QIcon icon);
     void setItemICon(int index, QIcon icon);
 
     /*
-    * @bref: setMenuButtonTextAndIcon 设置菜单按钮的文字和图标
-    */
+     * @bref: setMenuButtonTextAndIcon 设置菜单按钮的文字和图标
+     */
     void setMenuButtonTextAndIcon(QString text, QIcon ico);
 
 signals:
     /*
-    * @bref: signalCurrentIndexChanged 下标索引改变信号
-    */
+     * @bref: signalCurrentIndexChanged 下标索引改变信号
+     */
     void signalCurrentIndexChanged(int index);
     /*
-    * @bref: signalCurrentTextChanged 文本改变信号
-    */
+     * @bref: signalCurrentTextChanged 文本改变信号
+     */
     void signalCurrentTextChanged(QString text);
     /*
-    * @bref: signalLeftBtnClicked 左侧按钮点击信号
-    */
+     * @bref: signalLeftBtnClicked 左侧按钮点击信号
+     */
     void signalLeftBtnClicked();
     /*
-    * @bref: signalRightBtnClicked 右侧按钮点击信号
-    */
+     * @bref: signalRightBtnClicked 右侧按钮点击信号
+     */
     void signalRightBtnClicked();
 
 protected slots:
     /*
-    * @bref: slotActionToggled 处理子选项点击事件
-    */
+     * @bref: slotActionToggled 处理子选项点击事件
+     */
     void slotActionToggled(QAction *action);
-
+    void setSizeMode(bool isCompact);
 
 protected:
     bool eventFilter(QObject *o, QEvent *e) override;
 
 private:
-    DIconButton *m_reduceBtn; // 减少按钮
-    DIconButton *m_increaseBtn; // 增加按钮
+    DIconButton *m_reduceBtn;    // 减少按钮
+    DIconButton *m_increaseBtn;  // 增加按钮
     int m_floatingSize;
 
-    QPushButton *m_btn; // 菜单按钮
-    QMenu *m_menu; // 下拉菜单
-    QList<QAction *> m_actions; // 子菜单项
-    int m_currentIndex; // 选中的子菜单索引
+    QPushButton *m_btn;          // 菜单按钮
+    QMenu *m_menu;               // 下拉菜单
+    QList<QAction *> m_actions;  // 子菜单项
+    int m_currentIndex;          // 选中的子菜单索引
 
     QHBoxLayout *_btnLay = nullptr;
+    bool m_isCompact = false;  // 是否为紧凑模式
 
     void initUI();
     void initConnection();
 };
 
-#endif // DZOOMMENUCOMBOBOX_H
+#endif  // DZOOMMENUCOMBOBOX_H


### PR DESCRIPTION
添加紧凑模式切换时，标题栏切换百分比按钮
调整大小及布局，DTK在5.6.4版本后提供紧凑
模式接口。

Log: 修复紧凑模式下百分比按钮显示异常
Bug: https://pms.uniontech.com/bug-view-193945.html
Influence: 标题栏