### PR TITLE
chore: Update version to 6.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-draw (6.0.6) unstable; urgency=medium
+
+  * fix: Fix button in compact mode.(Bug: 193945)(Influence: TitleBar)
+  * fix: Adjust titlebar spacing in compact mode.(Bug: 193945)(Influence: TitleBar)
+  * fix: Keep float button align vertical center.(Bug: 193945)(Influence: TitleBar)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 31 May 2023 13:42:37 +0800
+
 deepin-draw (6.0.4) unstable; urgency=medium
 
   * update version to 6.0.4


### PR DESCRIPTION
Update version to 6.0.6
适配紧凑模式，相关PR：
* https://github.com/linuxdeepin/deepin-draw/pull/71
* https://github.com/linuxdeepin/deepin-draw/pull/72
* https://github.com/linuxdeepin/deepin-draw/pull/73

Log: Update version to 6.0.6