### PR TITLE
fix: 解决图片保存后变为几MB的问题

### DIFF
--- a/src/drawshape/cdrawscene.cpp
+++ b/src/drawshape/cdrawscene.cpp
@@ -1776,7 +1776,7 @@ QImage PageScene::renderToImage(const QColor &bgColor, const QSize &desImageSize
     this->setBgColor(bgColor);
     this->setBackgroundBrush(Qt::transparent);
 
-    image = QImage(desImageSize.isValid() ? desImageSize : scene->sceneRect().size().toSize(), QImage::Format_ARGB32);
+    image = QImage(desImageSize.isValid() ? desImageSize : scene->sceneRect().size().toSize(), QImage::Format_RGB32);
     image.fill(Qt::transparent);
     QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing);

--- a/src/service/filehander.h
+++ b/src/service/filehander.h
@@ -51,7 +51,7 @@ public:
     bool   saveToImage(PageContext *context,
                        const QString &file = "",
                        const QSize &desImageSize = QSize(),
-                       int imageQuility = 100);
+                       int imageQuility = -1);
 
     QString lastErrorDescribe()const;
     int lastError()const;


### PR DESCRIPTION
    成像质量从100调整为-1，使用默认值成像，因画板背景色为白色，保存alpha通道无意义，因此不保存alpha通道值

Log: 解决图片保存后变为几MB的问题
Bug: https://pms.uniontech.com/bug-view-207563.html