### PR TITLE
fix: 修复图片保存为tif格式后，文件过大的问题

### DIFF
--- a/src/service/filehander.cpp
+++ b/src/service/filehander.cpp
@@ -672,7 +672,13 @@ bool FileHander::saveToImage(PageContext *context, const QString &file, const QS
             painter.drawImage(0, 0, image);
             return true;
         }
-        return image.save(file, stuff.toLocal8Bit(), imageQuility);
+        if (stuff.toLower() == "tiff" || stuff.toLower() == "tif") {
+            // tiff文件，采用LZW压缩方式保存，解决保存后文件过大的问题
+            QImageWriter w(file, stuff.toLocal8Bit());
+            w.setCompression(1);
+            return w.write(image);
+        } else
+            return image.save(file, stuff.toLocal8Bit(), imageQuility);
     }
     return false;
 }


### PR DESCRIPTION
   tif格式图片使用QImageWriter保存，采用LZW压缩格式将压缩数据写入文件

Log: 修复图片保存为tif格式后，文件过大的问题
Bug: https://pms.uniontech.com/bug-view-207563.html