### PR TITLE
fix: 修复家目录更改后，画板启动失败的问题

### DIFF
--- a/src/deepin-draw/main.cpp
+++ b/src/deepin-draw/main.cpp
@@ -36,8 +36,7 @@ QStringList getFilesFromQCommandLineParser(const QCommandLineParser &parser)
 bool checkOnly()
 {
     //single
-    QString userName = QDir::homePath().section("/", -1, -1);
-    std::string path = ("/home/" + userName + "/.cache/deepin/deepin-draw/").toStdString();
+    std::string path = (QDir::homePath() + "/.cache/deepin/deepin-draw/").toStdString();
     QDir tdir(path.c_str());
     if (!tdir.exists()) {
         bool ret =  tdir.mkpath(path.c_str());


### PR DESCRIPTION
  家目录路径被写死，改为QDir:homme()获取家目录路径

Log: 修复家目录更改后，画板启动失败的问题