### PR TITLE
chore: Update version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.0.8) unstable; urgency=medium
+
+  * fix: After the home directory is changed, deepin-draw fails to start.
+
+ -- renbin <renbin@uniontech.com>  Wed, 30 Aug 2023 16:34:54 +0800
+
 deepin-draw (6.0.7) unstable; urgency=medium
 
   * fix: Solve the problem that the image becomes large after saving(Bug: 207563)


### PR DESCRIPTION
Update version to 6.0.8
相关PR：
* https://github.com/linuxdeepin/deepin-draw/pull/79

Log: Update version to 6.0.8