### PR TITLE
fix: 修复【画板】转换为ddf格式的图片无法打开

### DIFF
--- a/src/deepin-draw/drawfiles/mainwindow.cpp
+++ b/src/deepin-draw/drawfiles/mainwindow.cpp
@@ -208,6 +208,7 @@ void MainWindow::initConnection()
         if (drawBoard()->close())
         {
             drawApp->quitApp();
+            _Exit(0);//确保正常退出
         }
     });
 


### PR DESCRIPTION
修复【画板】转换为ddf格式的图片无法打开

Bug: https://pms.uniontech.com/bug-view-253321.html
Log: 修复【画板】转换为ddf格式的图片无法打开