### PR TITLE
fix: the null pointer reference vulnerability

### DIFF
--- a/src/service/filehander.cpp
+++ b/src/service/filehander.cpp
@@ -823,7 +823,7 @@ bool FileHander::isDdfFileDirty(const QString &filePath)const
                 if (md5 != nMd5) {
                     return true;
                 }
-            } else  if (ver == EDdfUnknowed) {
+            } else{
                 return true;
             }
             return false;


### PR DESCRIPTION
Fix the null pointer reference vulnerability.Use the MD5 check to check the file.

Log: Fix the null pointer reference vulnerability.
Bug: https://pms.uniontech.com/bug-view-252519.html