### PR TITLE
fix: too much latency when drawing on 4k screens

### DIFF
--- a/src/drawshape/drawTools/cpentool.cpp
+++ b/src/drawshape/drawTools/cpentool.cpp
@@ -483,7 +483,7 @@ void CPenTool::paintPictureToView(const QPicture &picture, PageView *view)
 
     painter.drawPicture(QPoint(0, 0), picture);
 
-    view->viewport()->update();
+    view->viewport()->update(trans.mapRect(picture.boundingRect()));
 }
 
 bool CPenTool::eventFilter(QObject *o, QEvent *e)


### PR DESCRIPTION
The entire area is refreshed when drawing

Log: The delay is too high when drawing on a 4k screen
Bug: https://pms.uniontech.com/bug-view-262599.html