### PR TITLE
fix: simplify file path validation

### DIFF
--- a/src/service/filehander.cpp
+++ b/src/service/filehander.cpp
@@ -378,7 +378,8 @@ struct STreePlatInfo {
 void serializationTree_helper_1(QDataStream &countStream, int &bzItemCount, int &groupCount,
                                 const CGroupBzItemsTreeInfo &tree, std::function<void(int, int)> f = nullptr)
 {
-    countStream << tree.childGroups.size();
+    // Note: Use int to ensure serialization consistency (after Qt6, size() uses qsizetype, default 8 bytes)
+    countStream << int(tree.childGroups.size());
 
     qDebug() << "save group count  = " << tree.childGroups.size();
 
@@ -387,7 +388,7 @@ void serializationTree_helper_1(QDataStream &countStream, int &bzItemCount, int 
         serializationTree_helper_1(countStream, bzItemCount, groupCount, p, f);
     }
 
-    countStream << tree.bzItems.size();
+    countStream << int(tree.bzItems.size());
 
     qDebug() << "save item count   = " << tree.bzItems.size();
 

--- a/src/service/filehander.cpp
+++ b/src/service/filehander.cpp
@@ -543,35 +543,19 @@ QStringList FileHander::supDdfStuffix()
     static QStringList supDdfSuffixs = QStringList() << "ddf";
     return supDdfSuffixs;
 }
+
+/**
+   @brief check input file path is valid, must be a file name and dir exits.
+ */
 bool FileHander::isLegalFile(const QString &path)
 {
     if (path.isEmpty()) {
         return false;
     }
 
-//    QRegExp regExp("[:\\*\\?\"<>\\|]");
-
-//    if (path.contains(regExp)) {
-//        return false;
-//    }
-
-    QRegularExpression splitExp("[/\\\\]");
-
-    int pos = splitExp.match(path).hasMatch() ? 0 : -1;
-
-    while (pos != -1) {
-        QString dirStr = path.left(pos + 1);
-        if (dirStr.size() > 1) {
-            QDir dir(dirStr);
-            if (!dir.exists()) {
-                return false;
-            }
-        }
-        pos = splitExp.match(path.mid(pos + 1)).hasMatch() ? pos + 1 : -1;
-    }
-
-    bool isdir = (path.endsWith('/') || path.endsWith('\\'));
-    return !isdir;
+    QFileInfo info(path);
+    QDir dir = info.absoluteDir();
+    return dir.exists() && !info.isDir();
 }
 
 QString FileHander::toLegalFile(const QString &filePath)


### PR DESCRIPTION
Refactor isLegalFile() to use QFileInfo/QDir for simpler path validation:
- Ensure parent directory exists
- Verify path is not a directory
- Remove complex regex parsing

Log: Improved file path validation reliability
Bug: https://pms.uniontech.com/bug-view-303265.html

[fix: Read ddf file data failed](https://github.com/linuxdeepin/deepin-draw/pull/131/commits/ab37029321e5fd290a69fc09b01054a80a5e61be) 

Ensure serialization consistency, after Qt6,
size() uses qsizetype, default 8 bytes.

Log: Fix read ddf file failed.