### PR TITLE
fix: can not select image /  resize item

### DIFF
--- a/src/drawshape/cdrawscene.cpp
+++ b/src/drawshape/cdrawscene.cpp
@@ -947,7 +947,12 @@ bool PageScene::isBussizeHandleNodeItem(QGraphicsItem *pItem)
     if (pItem == nullptr)
         return false;
     //CSizeHandleRect的父类QGraphicsSvgItem的类型就是13
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // In Qt6, default type() of QGraphicsSvgItem is changed, from Type to UserType
+    if (pItem->type() == QGraphicsSvgItem::UserType) {
+#else
     if (pItem->type() == QGraphicsSvgItem::Type) {
+#endif
         CSizeHandleRect *pHandleItem = dynamic_cast<CSizeHandleRect *>(pItem);
         if (pHandleItem != nullptr) {
             return true;

--- a/src/drawshape/drawTools/cpicturetool.cpp
+++ b/src/drawshape/drawTools/cpicturetool.cpp
@@ -222,7 +222,7 @@ void CPictureTool::onStatusChanged(EStatus oldStatus, EStatus nowStatus)
         auto formatsList = drawApp->readableFormats();
         if (!formatsList.isEmpty())
             formatsList.removeFirst();
-        auto formats = QString(" *.") + formatsList.join(" *.");
+        auto formats = QString("(*.") + formatsList.join(" *.") + QString(")");
         filters << formats;
 
         fileDialog.setNameFilters(filters);


### PR DESCRIPTION
[fix: can not select image](https://github.com/linuxdeepin/deepin-draw/commit/9988f8c3e7bdb86e1ea3ce63aebb3f0e5414981c) 

As title.

Log: fix can not select image.
Bug: https://pms.uniontech.com/bug-view-304191.html

[fix: can not resize item](https://github.com/linuxdeepin/deepin-draw/commit/4cdeadd58c2f8634e2bb074ac78fbafa6d198c06) 

The default value of QGraphicsItem::type() is changed,
from Type to UserType.

Log: fix can not resize item.
Bug: https://pms.uniontech.com/bug-view-304153.html