### PR TITLE
chore: Bump version to 6.5.15

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Draw for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.15) unstable; urgency=medium
+
+  * chore: update desktop file
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 13:03:37 +0800
+
 deepin-draw (6.5.14) unstable; urgency=medium
 
   * fix: can not open image(Bug: 306393)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Draw for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     Draw for deepin os.


### PR DESCRIPTION
Bump version to 6.5.15

Log: Bump version to 6.5.15

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main platforms