### PR TITLE
fix: Release to unstable.

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.8.1
+  version: 6.5.9.1
   kind: app
   description: |
     Draw for UOS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.9) unstable; urgency=medium
+
+  * Update version to 6.5.9.
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Wed, 14 May 2025 14:35:56 +0800
+
 deepin-draw (6.5.8) unstable; urgency=medium
 
   * chore: New version 6.5.8.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.8.1
+  version: 6.5.9.1
   kind: app
   description: |
     Draw for UOS

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.8.1
+  version: 6.5.9.1
   kind: app
   description: |
     Draw for UOS


### PR DESCRIPTION
Release 6.5.9

Log: Release 6.5.9

## Summary by Sourcery

Bump deepin-draw package to version 6.5.9.1 for the unstable release

Chores:
- Update package version from 6.5.8.1 to 6.5.9.1 in arm64, loong64, and generic YAML manifests
- Refresh Debian changelog for the 6.5.9 release