### PR TITLE
fix: Release to unstable.

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     Draw for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.16) unstable; urgency=medium
+
+  * Update version to 6.5.16. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Wed, 14 May 2025 15:27:46 +0800
+
 deepin-draw (6.5.15) unstable; urgency=medium
 
   * chore: update desktop file

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     Draw for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.15.1
+  version: 6.5.16.1
   kind: app
   description: |
     Draw for deepin os.


### PR DESCRIPTION
Release 6.5.16

Log: Release 6.5.16

## Summary by Sourcery

Bump deepin-draw release to 6.5.16.1 across all architectures and update the Debian changelog.

Chores:
- Bump package version from 6.5.15.1 to 6.5.16.1 in ARM64, generic, and Loong64 YAML manifests
- Update Debian changelog entry for deepin-draw 6.5.16 release