### PR TITLE
fix: test CI

### DIFF
--- a/src/deepin-draw/main.cpp
+++ b/src/deepin-draw/main.cpp
@@ -100,6 +100,7 @@ int main(int argc, char *argv[])
     qWarning() << QObject::tr("A picture is worth a thousand words");
     qWarning() << QObject::tr("Actions speak louder than words");
     qWarning() << QObject::tr("Better late than never");
+    qWarning() << QObject::tr("I'm sorry, I don't understand");
 
     QCommandLineOption openImageOption(QStringList() << "o" << "open",
                                        "Specify a path to load an image.", "PATH");

--- a/translations/deepin-draw_en.ts
+++ b/translations/deepin-draw_en.ts
@@ -1499,6 +1499,11 @@ Please save it in another name or close that file and try again.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/deepin-draw/main.cpp" line="103"/>
+        <source>I&apos;m sorry, I don&apos;t understand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/drawshape/drawTools/crecttool.cpp" line="68"/>
         <source>Stroke</source>
         <translation type="unfinished">Stroke</translation>

--- a/translations/deepin-draw_en_US.ts
+++ b/translations/deepin-draw_en_US.ts
@@ -2,43 +2,83 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US">
 <context>
+    <name>AdjustmentAtrriWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="39"/>
+        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="43"/>
+        <source>Auto fit</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Application</name>
     <message>
-        <location filename="../src/application.cpp" line="427"/>
+        <location filename="../src/application.cpp" line="396"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="104"/>
-        <location filename="../src/application.cpp" line="150"/>
+        <location filename="../src/application.cpp" line="96"/>
+        <location filename="../src/application.cpp" line="142"/>
+        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="62"/>
+        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="108"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="426"/>
+        <location filename="../src/application.cpp" line="395"/>
         <source>You can import up to 30 pictures, please try again!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlurAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="244"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlurAttributionWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="22"/>
+        <source>Blur</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="23"/>
+        <source>Mosaic</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlurTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="47"/>
+        <source>Blur (B)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BlurWidget</name>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="100"/>
+        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="84"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="110"/>
+        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="94"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="123"/>
+        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="107"/>
         <source>Mosaic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="146"/>
+        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="130"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,7 +86,7 @@
 <context>
     <name>CAbstractProcessDialog</name>
     <message>
-        <location filename="../src/widgets/dialog/cprogressdialog.cpp" line="105"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="101"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -54,7 +94,7 @@
 <context>
     <name>CAlphaControlWidget</name>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/calphacontrolwidget.cpp" line="65"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="52"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
@@ -62,17 +102,17 @@
 <context>
     <name>CCutDialog</name>
     <message>
-        <location filename="../src/widgets/dialog/ccutdialog.cpp" line="41"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/ccutdialog.cpp" line="42"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/ccutdialog.cpp" line="47"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="58"/>
         <source>Do you want to save the cropped image?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -80,35 +120,40 @@
 <context>
     <name>CCutTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/ccuttool.cpp" line="90"/>
+        <location filename="../src/drawshape/drawTools/ccuttool.cpp" line="74"/>
         <source>Crop (C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="86"/>
+        <source>Crop canvas (C)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CCutWidget</name>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="230"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="231"/>
         <source>Dimensions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="245"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="246"/>
         <source>x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="295"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="296"/>
         <source>Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="336"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="337"/>
         <source>Free</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="343"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="344"/>
         <source>Original</source>
         <translation type="unfinished"></translation>
     </message>
@@ -116,7 +161,7 @@
 <context>
     <name>CEllipseTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cellipsetool.cpp" line="57"/>
+        <location filename="../src/drawshape/drawTools/cellipsetool.cpp" line="41"/>
         <source>Ellipse (O)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,12 +169,12 @@
 <context>
     <name>CEraserTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="98"/>
+        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="63"/>
         <source>Eraser (E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="113"/>
+        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="78"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -137,165 +182,203 @@
 <context>
     <name>CExportImageDialog</name>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="548"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="432"/>
         <source>Percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="562"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="460"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="564"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="462"/>
         <source>Dimensions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="586"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="471"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="595"/>
-        <source>W:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="600"/>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="611"/>
-        <source>pixels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="605"/>
-        <source>H:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="868"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="795"/>
         <source>It supports up to 10,000 pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="98"/>
-        <source>Unnamed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="173"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="163"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="186"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="181"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="188"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="182"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="189"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="183"/>
         <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="190"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="184"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="191"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="185"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="192"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="186"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="193"/>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="207"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="187"/>
         <source>Select other directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="265"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="191"/>
+        <source>png</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="192"/>
+        <source>jpg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="193"/>
+        <source>bmp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="194"/>
+        <source>tif</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="195"/>
+        <source>pdf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="196"/>
+        <source>ppm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="197"/>
+        <source>xbm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="198"/>
+        <source>xpm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="230"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="266"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="231"/>
         <source>Save to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="268"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="233"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="269"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="235"/>
         <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="275"/>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="281"/>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="407"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="241"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="276"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="242"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="282"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="406"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="320"/>
         <source>This file will be hidden if the file name starts with a dot (.). Do you want to hide it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="407"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="421"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="423"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="333"/>
         <source>The file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="506"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="397"/>
         <source>%1 
  already exists, do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/cexportimagedialog.cpp" line="866"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="479"/>
+        <source>W</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="495"/>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="793"/>
         <source>At least one pixel please</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CGroupButtonWgt</name>
+    <message>
+        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="472"/>
+        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="484"/>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="475"/>
+        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="492"/>
+        <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CLineTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/clinetool.cpp" line="58"/>
+        <location filename="../src/drawshape/drawTools/clinetool.cpp" line="42"/>
         <source>Line (L)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -303,37 +386,37 @@
 <context>
     <name>CPenTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="79"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="62"/>
         <source>Pencil (P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="96"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="79"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="124"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="107"/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="167"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="150"/>
         <source>Watercolor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="168"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="151"/>
         <source>Calligraphy pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="169"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="152"/>
         <source>Crayon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="514"/>
+        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="497"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
@@ -341,37 +424,37 @@
 <context>
     <name>CPictureTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="87"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="51"/>
         <source>Import (I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="114"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="78"/>
         <source>Rotate 90° CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="132"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="96"/>
         <source>Rotate 90° CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="149"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="113"/>
         <source>Flip horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="169"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="133"/>
         <source>Flip vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="188"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="152"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="232"/>
+        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="196"/>
         <source>Import Picture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -379,12 +462,12 @@
 <context>
     <name>CPolygonTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="69"/>
+        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="53"/>
         <source>Polygon (H)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="86"/>
+        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="70"/>
         <source>Sides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -392,17 +475,17 @@
 <context>
     <name>CPolygonalStarTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="49"/>
+        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="33"/>
         <source>Star (F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="90"/>
+        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="74"/>
         <source>Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="97"/>
+        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="81"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -410,22 +493,22 @@
 <context>
     <name>CRectTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="68"/>
+        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="52"/>
         <source>Rectangle (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="136"/>
+        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="120"/>
         <source>Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="142"/>
+        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="126"/>
         <source>Corner Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="273"/>
+        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="257"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -433,12 +516,12 @@
 <context>
     <name>CSelectTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="90"/>
+        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="74"/>
         <source>Select (V)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="124"/>
+        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="108"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -446,32 +529,32 @@
 <context>
     <name>CTextTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="68"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="52"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="99"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="83"/>
         <source>Text (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="229"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="214"/>
         <source>Input text here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="328"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="313"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="344"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="329"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="469"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="454"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -479,112 +562,327 @@
 <context>
     <name>CTriangleTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/ctriangletool.cpp" line="62"/>
+        <location filename="../src/drawshape/drawTools/ctriangletool.cpp" line="46"/>
         <source>Triangle (S)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CloseTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="176"/>
+        <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ColorPanel</name>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/colorpanel.cpp" line="175"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="80"/>
+        <source>Color palette</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="108"/>
+        <location filename="../src/frame/AttributesWidgets/private/colorpanel.cpp" line="159"/>
         <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="208"/>
+        <source>More colors</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DrawAttribution::CGroupButtonWgt</name>
+    <name>ColorStyleWidget</name>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="487"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="499"/>
-        <source>Group</source>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="66"/>
+        <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="490"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="507"/>
-        <source>Ungroup</source>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="81"/>
+        <source>Fill</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonAttributionRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="66"/>
+        <source>Stroke</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CutAttributionWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="30"/>
+        <source>Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <source>Free</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="83"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="84"/>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DataHander</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="82"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="109"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="126"/>
+        <source>Unable to open &quot;%1&quot;, unsupported file format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="89"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="138"/>
+        <source>This file is read-only, please save with another name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="103"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="143"/>
+        <source>The file does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="115"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="133"/>
+        <source>Unable to open the write-only file &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="150"/>
+        <source>Unable to open the broken file &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdfHander</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="224"/>
+        <source>Opening...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="256"/>
+        <source>Saving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="302"/>
+        <source>Unable to open the broken file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdfUnitProccessor_5_8_0_20</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="105"/>
+        <source>Unable to open the broken file &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdfUnitProccessor_5_8_0_Compatibel</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="723"/>
+        <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="732"/>
+        <source>The pen effect will be lost as the file is in old version. Proceed to open it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DdfUnitProccessor_chaos</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="380"/>
+        <source>Saving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="548"/>
+        <source>Unable to save. There is not enough disk space.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DrawBoard</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="208"/>
+        <source>The file does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="220"/>
+        <source>Unable to open the write-only file &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="225"/>
+        <source>Unable to open &quot;%1&quot;, unsupported file format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1874"/>
+        <source>You can import up to 30 pictures, please try again!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1875"/>
+        <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DrawDialog</name>
     <message>
-        <location filename="../src/widgets/dialog/drawdialog.cpp" line="42"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="32"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/drawdialog.cpp" line="43"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="33"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/drawdialog.cpp" line="44"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="34"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/drawdialog.cpp" line="47"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="36"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
         <source>Save the current contents?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EllipseTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="25"/>
+        <source>Ellipse (O)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EraserAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="229"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EraserTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="41"/>
+        <source>Eraser (E)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FileHander</name>
     <message>
-        <location filename="../src/service/filehander.cpp" line="596"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="549"/>
+        <location filename="../src/service/filehander.cpp" line="586"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="623"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="573"/>
+        <location filename="../src/service/filehander.cpp" line="613"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="650"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="606"/>
+        <location filename="../src/service/filehander.cpp" line="640"/>
         <source>Damaged file, unable to open it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="705"/>
-        <location filename="../src/service/filehander.cpp" line="828"/>
+        <location filename="../src/service/filehander.cpp" line="695"/>
+        <location filename="../src/service/filehander.cpp" line="835"/>
         <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="724"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="676"/>
+        <location filename="../src/service/filehander.cpp" line="714"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="749"/>
+        <location filename="../src/service/filehander.cpp" line="739"/>
         <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="839"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="780"/>
+        <location filename="../src/service/filehander.cpp" line="846"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="852"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="793"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="801"/>
+        <location filename="../src/service/filehander.cpp" line="859"/>
         <source>This file is read-only, please save with another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="860"/>
+        <location filename="../src/service/filehander.cpp" line="867"/>
         <source>You do not have permission to save files here, please change and retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="881"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="822"/>
+        <location filename="../src/service/filehander.cpp" line="888"/>
         <source>The file is incompatible with the old app, please install the latest version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="899"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="838"/>
+        <location filename="../src/service/filehander.cpp" line="906"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -592,57 +890,188 @@
 <context>
     <name>FileSelectDialog</name>
     <message>
-        <location filename="../src/frame/cmultiptabbarwidget.cpp" line="202"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="186"/>
         <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cmultiptabbarwidget.cpp" line="204"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cmultiptabbarwidget.cpp" line="231"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="199"/>
         <source>Cannot save it as %1, since the file in that name is open now.
 Please save it in another name or close that file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>FillTool</name>
+    <message>
+        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="84"/>
+        <source>Paint bucket</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GroupButtonWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="22"/>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="37"/>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="31"/>
+        <source>Ungroup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>IBlurTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/cmasicotool.cpp" line="148"/>
+        <location filename="../src/drawshape/drawTools/cmasicotool.cpp" line="137"/>
         <source>Blur (B)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageHander</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="238"/>
+        <source>Damaged file, unable to open it</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageLoadTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="25"/>
+        <source>Import (I)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="78"/>
+        <source>Import Picture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LineTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="24"/>
+        <source>Line (L)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/frame/mainwindow.cpp" line="105"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="131"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/mainwindow.cpp" line="200"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
         <source>Export successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/mainwindow.cpp" line="200"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/mainwindow.cpp" line="228"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="283"/>
         <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NumberSlider</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="33"/>
+        <source>Percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="195"/>
+        <source>Import Picture</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OrderWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="25"/>
+        <source>Order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="26"/>
+        <source>Raise layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="27"/>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="28"/>
+        <source>Layer to Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="29"/>
+        <source>Layer to Bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="31"/>
+        <source>Align left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="32"/>
+        <source>Align center horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="33"/>
+        <source>Align right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="34"/>
+        <source>Align top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="35"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="36"/>
+        <source>Align bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="38"/>
+        <source>Distribute horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="39"/>
+        <source>Distribute vertically</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageContext</name>
     <message>
-        <location filename="../src/drawshape/cdrawparamsigleton.cpp" line="66"/>
+        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="62"/>
+        <location filename="../src/drawshape/cdrawparamsigleton.cpp" line="50"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -650,548 +1079,995 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PageView</name>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="322"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="666"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="472"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="306"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="650"/>
         <source>Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="324"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="683"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="474"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="308"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="667"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="329"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="684"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="479"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="313"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="668"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="334"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="685"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="484"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="318"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="669"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="341"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="686"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="491"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="325"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="670"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="348"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="692"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="498"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="332"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="676"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="354"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="687"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="504"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="338"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="671"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="363"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="688"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="513"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="347"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="672"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="372"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="522"/>
+        <source>Raise layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="527"/>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="585"/>
+        <source>Align center horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="600"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="610"/>
+        <source>Distribute horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="612"/>
+        <source>Distribute vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/frame/cgraphicsview.cpp" line="356"/>
         <source>Raise Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="377"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="361"/>
         <source>Lower Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="382"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="532"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="366"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="387"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="537"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="371"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="416"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="566"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="400"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="421"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="571"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="405"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="427"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="577"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="411"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="430"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="580"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="414"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="435"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="419"/>
         <source>Horizontal centers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="440"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="590"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="424"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="445"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="595"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="429"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="450"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="434"/>
         <source>Vertical centers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="455"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="605"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="439"/>
         <source>Align bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="460"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="444"/>
         <source>Distribute horizontal space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="462"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="446"/>
         <source>Distribute vertical space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="689"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="673"/>
         <source>Text Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="690"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="674"/>
         <source>Text Align Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="691"/>
+        <location filename="../src/frame/cgraphicsview.cpp" line="675"/>
         <source>Text Align Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PenAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="319"/>
+        <source>Brush</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="329"/>
+        <source>Watercolor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="330"/>
+        <source>Calligraphy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="331"/>
+        <source>Crayon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="352"/>
+        <source>Brush size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PenTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="256"/>
+        <source>Pencil (P)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PickColorWidget</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="327"/>
+        <source>Color picker</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PolygonSidesAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="144"/>
+        <source>Sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PolygonTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="22"/>
+        <source>Polygon (H)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/service/filehander.cpp" line="103"/>
+        <location filename="../src/service/filehander.cpp" line="89"/>
         <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="104"/>
-        <location filename="../src/service/filehander.cpp" line="129"/>
-        <location filename="../src/service/filehander.cpp" line="203"/>
+        <location filename="../src/service/filehander.cpp" line="90"/>
+        <location filename="../src/service/filehander.cpp" line="115"/>
+        <location filename="../src/service/filehander.cpp" line="189"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="104"/>
-        <location filename="../src/service/filehander.cpp" line="129"/>
-        <location filename="../src/service/filehander.cpp" line="203"/>
-        <location filename="../src/frame/ccentralwidget.cpp" line="757"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="385"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="814"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="386"/>
+        <location filename="../src/service/filehander.cpp" line="90"/>
+        <location filename="../src/service/filehander.cpp" line="115"/>
+        <location filename="../src/service/filehander.cpp" line="189"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="128"/>
-        <location filename="../src/service/filehander.cpp" line="202"/>
+        <location filename="../src/service/filehander.cpp" line="114"/>
+        <location filename="../src/service/filehander.cpp" line="188"/>
         <source>The file is in an older version, and the properties of elements will be changed. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="462"/>
+        <location filename="../src/service/filehander.cpp" line="452"/>
         <source>Unable to save. There is not enough disk space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/mainwindow.cpp" line="75"/>
-        <location filename="../src/frame/cviewmanagement.cpp" line="202"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="60"/>
+        <location filename="../src/frame/cviewmanagement.cpp" line="186"/>
         <source>File not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="287"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="346"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="296"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="356"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="300"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="359"/>
         <source>The dimensions of %1 exceed the canvas. How to display it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="755"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="812"/>
         <source>%1 has been modified in other programs. Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="756"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="813"/>
         <source>Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="1289"/>
-        <location filename="../src/frame/ccentralwidget.cpp" line="1691"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1369"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1796"/>
         <source>Import failed: no more than 10,000 pixels please</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="355"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="66"/>
+        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="179"/>
+        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="340"/>
         <source>Source Han Sans CN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="84"/>
+        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="68"/>
         <source>Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="289"/>
-        <location filename="../src/frame/ccentralwidget.cpp" line="301"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
         <source>Keep original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/ccentralwidget.cpp" line="289"/>
-        <location filename="../src/frame/ccentralwidget.cpp" line="301"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/dialog/dialog.h" line="45"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="374"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="45"/>
+        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="375"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/progresslayout.cpp" line="37"/>
-        <location filename="../src/frame/ccentralwidget.cpp" line="1224"/>
+        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="25"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/progresslayout.cpp" line="158"/>
+        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="152"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/application.cpp" line="64"/>
         <location filename="../src/application.cpp" line="72"/>
-        <location filename="../src/application.cpp" line="80"/>
+        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="17"/>
+        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="28"/>
         <source>DDF Drawings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="95"/>
+        <source>The quick brown fox jumps over the lazy dog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="96"/>
+        <source>All work and no play makes Jack a dull boy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="97"/>
+        <source>To be or not to be, that is the question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="98"/>
+        <source>Now is the time for all good men to come to the aid of their country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="99"/>
+        <source>The early bird catches the worm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="100"/>
+        <source>A picture is worth a thousand words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="101"/>
+        <source>Actions speak louder than words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="102"/>
+        <source>Better late than never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="103"/>
+        <source>I&apos;m sorry, I don&apos;t understand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/example/main.cpp" line="189"/>
+        <location filename="../src/drawboard/test/main.cpp" line="154"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/example/main.cpp" line="218"/>
+        <location filename="../src/drawboard/test/main.cpp" line="183"/>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/example/main.cpp" line="247"/>
+        <location filename="../src/drawboard/test/main.cpp" line="212"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RectRadiusStyleWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="74"/>
+        <source>Rounded corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="78"/>
+        <source>Same radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="87"/>
+        <source>Different radii</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="172"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RectTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="24"/>
+        <source>Rectangle (R)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RotateAttriWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="61"/>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="87"/>
+        <source>Flip horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="96"/>
+        <source>Flip vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="186"/>
+        <source>Please enter a value between -360 and 360</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SaveTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="155"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="157"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="84"/>
+        <source>Select (V)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Shortcut</name>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="34"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="15"/>
+        <location filename="../src/utils/shortcut.cpp" line="18"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="35"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="16"/>
+        <location filename="../src/utils/shortcut.cpp" line="19"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="36"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="17"/>
+        <location filename="../src/utils/shortcut.cpp" line="20"/>
         <source>Shapes/Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="37"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="18"/>
+        <location filename="../src/utils/shortcut.cpp" line="21"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="38"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="19"/>
+        <location filename="../src/utils/shortcut.cpp" line="22"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="42"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="23"/>
+        <location filename="../src/utils/shortcut.cpp" line="26"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="43"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="24"/>
+        <location filename="../src/utils/shortcut.cpp" line="27"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="44"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="25"/>
+        <location filename="../src/utils/shortcut.cpp" line="28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="45"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="26"/>
+        <location filename="../src/utils/shortcut.cpp" line="29"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="46"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="27"/>
+        <location filename="../src/utils/shortcut.cpp" line="30"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="47"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="28"/>
+        <location filename="../src/utils/shortcut.cpp" line="31"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="50"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="31"/>
+        <location filename="../src/utils/shortcut.cpp" line="34"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="51"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="32"/>
+        <location filename="../src/utils/shortcut.cpp" line="35"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="52"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="33"/>
+        <location filename="../src/utils/shortcut.cpp" line="36"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="53"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="34"/>
+        <location filename="../src/utils/shortcut.cpp" line="37"/>
         <source>Ellipse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="54"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="35"/>
+        <location filename="../src/utils/shortcut.cpp" line="38"/>
         <source>Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="55"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="36"/>
+        <location filename="../src/utils/shortcut.cpp" line="39"/>
         <source>Star</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="56"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="37"/>
+        <location filename="../src/utils/shortcut.cpp" line="40"/>
         <source>Polygon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="57"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="38"/>
+        <location filename="../src/utils/shortcut.cpp" line="41"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="59"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="40"/>
+        <location filename="../src/utils/shortcut.cpp" line="43"/>
         <source>Pencil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="58"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="58"/>
+        <source>Raise layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="59"/>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="70"/>
+        <source>Align center horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="73"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="39"/>
+        <location filename="../src/utils/shortcut.cpp" line="42"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="60"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="41"/>
+        <location filename="../src/utils/shortcut.cpp" line="44"/>
         <source>Eraser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="61"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="42"/>
+        <location filename="../src/utils/shortcut.cpp" line="45"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="62"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="43"/>
+        <location filename="../src/utils/shortcut.cpp" line="46"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="63"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="44"/>
+        <location filename="../src/utils/shortcut.cpp" line="47"/>
         <source>Expand canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="64"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="45"/>
+        <location filename="../src/utils/shortcut.cpp" line="48"/>
         <source>Shrink canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="69"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="50"/>
+        <location filename="../src/utils/shortcut.cpp" line="53"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="70"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="51"/>
+        <location filename="../src/utils/shortcut.cpp" line="54"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="71"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="52"/>
+        <location filename="../src/utils/shortcut.cpp" line="55"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="72"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="53"/>
+        <location filename="../src/utils/shortcut.cpp" line="56"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="73"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="54"/>
+        <location filename="../src/utils/shortcut.cpp" line="57"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="74"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="55"/>
+        <location filename="../src/utils/shortcut.cpp" line="58"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="75"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="56"/>
+        <location filename="../src/utils/shortcut.cpp" line="59"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="76"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="57"/>
+        <location filename="../src/utils/shortcut.cpp" line="60"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="77"/>
+        <location filename="../src/utils/shortcut.cpp" line="61"/>
         <source>Raise Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="78"/>
+        <location filename="../src/utils/shortcut.cpp" line="62"/>
         <source>Lower Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="79"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="60"/>
+        <location filename="../src/utils/shortcut.cpp" line="63"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="80"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="61"/>
+        <location filename="../src/utils/shortcut.cpp" line="64"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="84"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="65"/>
+        <location filename="../src/utils/shortcut.cpp" line="68"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="85"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="66"/>
+        <location filename="../src/utils/shortcut.cpp" line="69"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="87"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="68"/>
+        <location filename="../src/utils/shortcut.cpp" line="71"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="88"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="69"/>
+        <location filename="../src/utils/shortcut.cpp" line="72"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="89"/>
+        <location filename="../src/utils/shortcut.cpp" line="73"/>
         <source>Horizontal centers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="90"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="71"/>
+        <location filename="../src/utils/shortcut.cpp" line="74"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="91"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="72"/>
+        <location filename="../src/utils/shortcut.cpp" line="75"/>
         <source>Align bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="92"/>
+        <location filename="../src/utils/shortcut.cpp" line="76"/>
         <source>Vertical centers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StarAnchorAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="104"/>
+        <source>Vertices</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StarTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="23"/>
+        <source>Star (F)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StartAttriRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="124"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StyleAttriWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="57"/>
+        <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TabBarWgt</name>
     <message>
-        <location filename="../src/frame/cmultiptabbarwidget.cpp" line="120"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="111"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cmultiptabbarwidget.cpp" line="125"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="116"/>
         <source>Close other tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextAttributionRegister</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="27"/>
+        <source>Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="54"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="191"/>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextEdit</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="45"/>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="46"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="47"/>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="48"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="49"/>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="50"/>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="51"/>
+        <source>Text Align Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="52"/>
+        <source>Text Align Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="53"/>
+        <source>Text Align Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="54"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="90"/>
+        <source>Text (T)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="176"/>
+        <source>Input text here</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TopTilte</name>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="173"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="166"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="178"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="171"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="199"/>
-        <location filename="../src/frame/toptoolbar.cpp" line="225"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="187"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="189"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="177"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="194"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="49"/>
+        <source>Crop canvas (C)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="54"/>
+        <source>Unnamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="182"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="209"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="197"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="242"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="220"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/toptoolbar.cpp" line="245"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="223"/>
         <source>Draw is a lightweight drawing tool for users to freely draw and simply edit images. </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TriangleTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="23"/>
+        <source>Triangle (S)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UndoTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="63"/>
+        <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
log: test.

## Summary by Sourcery

Refresh and synchronize translation source files following code refactoring, and introduce a new user warning string

New Features:
- Add new user-facing warning “I’m sorry, I don’t understand”

Enhancements:
- Sync TS translation contexts and location references to match refactored source structure across deepin-draw and drawboard modules
- Add translation entries for numerous UI components (tools, widgets, dialogs, shortcuts) with updated contexts and labels
- Introduce a new warning message “I’m sorry, I don’t understand” in main.cpp with corresponding translation entries