### PR TITLE
fix: test CI

### DIFF
--- a/src/deepin-draw/main.cpp
+++ b/src/deepin-draw/main.cpp
@@ -100,7 +100,8 @@ int main(int argc, char *argv[])
     qWarning() << QObject::tr("A picture is worth a thousand words");
     qWarning() << QObject::tr("Actions speak louder than words");
     qWarning() << QObject::tr("Better late than never");
-    qWarning() << QObject::tr("I'm sorry, I don't understand");
+    qWarning() << QObject::tr("The best way to predict the future is to create it");
+    qWarning() << QObject::tr("Knowledge is power");
 
     QCommandLineOption openImageOption(QStringList() << "o" << "open",
                                        "Specify a path to load an image.", "PATH");

--- a/translations/deepin-draw.ts
+++ b/translations/deepin-draw.ts
@@ -4,8 +4,8 @@
 <context>
     <name>AdjustmentAtrriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="35"/>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="39"/>
+        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="+39"/>
+        <location line="+4"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13,22 +13,20 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../src/application.cpp" line="407"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="402"/>
+        <location filename="../src/application.cpp" line="+396"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="90"/>
-        <location filename="../src/application.cpp" line="136"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="78"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="124"/>
+        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="+62"/>
+        <location line="+46"/>
+        <location filename="../src/application.cpp" line="-300"/>
+        <location line="+46"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="406"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="401"/>
+        <location filename="../src/application.cpp" line="+253"/>
         <source>You can import up to 30 pictures, please try again!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -36,25 +34,28 @@
 <context>
     <name>BlurAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="243"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+244"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BlurAttributionWidget</name>
+    <message>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="+22"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="244"/>
+        <location line="+1"/>
         <source>Mosaic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="267"/>
-        <source>width</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BlurTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="64"/>
+        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="+47"/>
         <source>Blur (B)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -62,7 +63,7 @@
 <context>
     <name>CAbstractProcessDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="117"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="+101"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -70,7 +71,7 @@
 <context>
     <name>CAlphaControlWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="68"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="+52"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
@@ -78,17 +79,17 @@
 <context>
     <name>CCutDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="75"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="+59"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="75"/>
+        <location line="+0"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="74"/>
+        <location line="-1"/>
         <source>Do you want to save the cropped image?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -96,7 +97,7 @@
 <context>
     <name>CCutTool</name>
     <message>
-        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="102"/>
+        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="+86"/>
         <source>Crop canvas (C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -104,180 +105,180 @@
 <context>
     <name>CExportImageDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="432"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="+432"/>
         <source>Percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="460"/>
+        <location line="+28"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="462"/>
+        <location line="+2"/>
         <source>Dimensions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="471"/>
+        <location line="+9"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="797"/>
+        <location line="+324"/>
         <source>It supports up to 10,000 pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="185"/>
+        <location line="-632"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="203"/>
+        <location line="+18"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="204"/>
+        <location line="+1"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="205"/>
+        <location line="+1"/>
         <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="206"/>
+        <location line="+1"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="207"/>
+        <location line="+1"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="208"/>
+        <location line="+1"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="209"/>
+        <location line="+1"/>
         <source>Select other directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="214"/>
+        <location line="+5"/>
         <source>jpg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="213"/>
+        <location line="-1"/>
         <source>png</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="215"/>
+        <location line="+2"/>
         <source>bmp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="216"/>
+        <location line="+1"/>
         <source>tif</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="217"/>
+        <location line="+1"/>
         <source>pdf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="218"/>
+        <location line="+1"/>
         <source>ppm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="219"/>
+        <location line="+1"/>
         <source>xbm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="220"/>
+        <location line="+1"/>
         <source>xpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="252"/>
+        <location line="+32"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="253"/>
+        <location line="+1"/>
         <source>Save to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="254"/>
+        <location line="+2"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="256"/>
+        <location line="+2"/>
         <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="262"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="338"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+6"/>
+        <location line="+80"/>
+        <location line="+78"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="263"/>
+        <location line="-157"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+157"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="337"/>
+        <location line="-79"/>
         <source>This file will be hidden if the file name starts with a dot (.). Do you want to hide it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="338"/>
+        <location line="+1"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="350"/>
+        <location line="+12"/>
         <source>The file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="397"/>
+        <location line="+64"/>
         <source>%1 
  already exists, do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="479"/>
+        <location line="+82"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="495"/>
+        <location line="+16"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="795"/>
+        <location line="+298"/>
         <source>At least one pixel please</source>
         <translation type="unfinished"></translation>
     </message>
@@ -285,38 +286,38 @@
 <context>
     <name>CloseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="172"/>
-        <source>close</source>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+176"/>
+        <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ColorPanel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="84"/>
-        <source>color panel</source>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="+80"/>
+        <source>Color palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="117"/>
+        <location line="+28"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="211"/>
-        <source>More color</source>
+        <location line="+100"/>
+        <source>More colors</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ColorStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="61"/>
-        <source>color</source>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="+66"/>
+        <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="75"/>
+        <location line="+15"/>
         <source>Fill</source>
         <translation type="unfinished"></translation>
     </message>
@@ -324,68 +325,68 @@
 <context>
     <name>CommonAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="82"/>
-        <source>Border</source>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="+66"/>
+        <source>Stroke</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CutAttributionWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="26"/>
-        <source>scale</source>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="+30"/>
+        <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="57"/>
-        <source>original</source>
+        <location line="+32"/>
+        <source>Original</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="57"/>
-        <source>free</source>
+        <location line="+0"/>
+        <source>Free</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="77"/>
-        <source>cancel</source>
+        <location line="+21"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="78"/>
-        <source>confirm</source>
+        <location line="+1"/>
+        <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DataHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="78"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="105"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="122"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+82"/>
+        <location line="+27"/>
+        <location line="+17"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="85"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="134"/>
+        <location line="-37"/>
+        <location line="+49"/>
         <source>This file is read-only, please save with another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="99"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="139"/>
+        <location line="-35"/>
+        <location line="+40"/>
         <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="111"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="129"/>
+        <location line="-28"/>
+        <location line="+18"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="146"/>
+        <location line="+17"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -393,17 +394,17 @@
 <context>
     <name>DdfHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="220"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="+224"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="252"/>
+        <location line="+32"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="298"/>
+        <location line="+46"/>
         <source>Unable to open the broken file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -411,7 +412,7 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_20</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="101"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="+105"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -419,24 +420,24 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_Compatibel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="719"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="+723"/>
         <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="720"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="729"/>
+        <location line="+1"/>
+        <location line="+9"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="720"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="729"/>
+        <location line="-9"/>
+        <location line="+9"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="728"/>
+        <location line="-1"/>
         <source>The pen effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -444,12 +445,12 @@
 <context>
     <name>DdfUnitProccessor_chaos</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="376"/>
+        <location line="-352"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="544"/>
+        <location line="+168"/>
         <source>Unable to save. There is not enough disk space.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -457,44 +458,54 @@
 <context>
     <name>DrawBoard</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="214"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="+208"/>
         <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="226"/>
+        <location line="+12"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="231"/>
+        <location line="+5"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1649"/>
+        <source>You can import up to 30 pictures, please try again!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DrawDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="48"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="81"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="+32"/>
+        <location line="+33"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="49"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="81"/>
+        <location line="-32"/>
+        <location line="+32"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="50"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="81"/>
+        <location line="-31"/>
+        <location line="+31"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="52"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="81"/>
+        <location line="-29"/>
+        <location line="+29"/>
         <source>Save the current contents?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -502,7 +513,7 @@
 <context>
     <name>EllipseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="41"/>
+        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="+25"/>
         <source>Ellipse (O)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -510,15 +521,15 @@
 <context>
     <name>EraserAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="225"/>
-        <source>width</source>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-15"/>
+        <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="57"/>
+        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="+41"/>
         <source>Eraser (E)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -526,67 +537,43 @@
 <context>
     <name>FileHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="545"/>
-        <location filename="../src/service/filehander.cpp" line="593"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="+549"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="569"/>
-        <location filename="../src/service/filehander.cpp" line="620"/>
+        <location line="+24"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="602"/>
-        <location filename="../src/service/filehander.cpp" line="647"/>
+        <location line="+33"/>
         <source>Damaged file, unable to open it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="705"/>
-        <location filename="../src/service/filehander.cpp" line="828"/>
-        <source>The file does not exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="672"/>
-        <location filename="../src/service/filehander.cpp" line="721"/>
+        <location line="+70"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="749"/>
-        <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="776"/>
-        <location filename="../src/service/filehander.cpp" line="836"/>
+        <location line="+104"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="789"/>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="797"/>
-        <location filename="../src/service/filehander.cpp" line="849"/>
+        <location line="+13"/>
+        <location line="+8"/>
         <source>This file is read-only, please save with another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="860"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="818"/>
-        <location filename="../src/service/filehander.cpp" line="878"/>
+        <location line="+21"/>
         <source>The file is incompatible with the old app, please install the latest version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="834"/>
-        <location filename="../src/service/filehander.cpp" line="896"/>
+        <location line="+16"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -594,12 +581,12 @@
 <context>
     <name>FileSelectDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="202"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="+186"/>
         <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="215"/>
+        <location line="+13"/>
         <source>Cannot save it as %1, since the file in that name is open now.
 Please save it in another name or close that file and try again.</source>
         <translation type="unfinished"></translation>
@@ -608,7 +595,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="100"/>
+        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="+84"/>
         <source>Paint bucket</source>
         <translation type="unfinished"></translation>
     </message>
@@ -616,25 +603,21 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>GroupButtonWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="17"/>
-        <source>group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="26"/>
-        <source>ungroup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="32"/>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="+22"/>
+        <location line="+15"/>
         <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-6"/>
+        <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="234"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+88"/>
         <source>Damaged file, unable to open it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -642,12 +625,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>ImageLoadTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="42"/>
+        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="+25"/>
         <source>Import (I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="95"/>
+        <location line="+53"/>
         <source>Import Picture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -655,7 +638,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>LineTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="40"/>
+        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="+24"/>
         <source>Line (L)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -663,22 +646,22 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="135"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="+131"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="243"/>
+        <location line="+108"/>
         <source>Export successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="243"/>
+        <location line="+0"/>
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="274"/>
+        <location line="+44"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -686,15 +669,15 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>NumberSlider</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="49"/>
-        <source>Percent</source>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="+33"/>
+        <source>Percentage</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OpenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="191"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+19"/>
         <source>Import Picture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -702,67 +685,67 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>OrderWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="19"/>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="+25"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="20"/>
+        <location line="+1"/>
         <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="21"/>
+        <location line="+1"/>
         <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="22"/>
+        <location line="+1"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="23"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="25"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="26"/>
-        <source>Align middle</source>
+        <location line="+1"/>
+        <source>Align center horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="27"/>
+        <location line="+3"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="28"/>
+        <location line="+1"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="29"/>
-        <source>Align center</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="30"/>
+        <location line="+2"/>
         <source>Align bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="32"/>
+        <location line="+2"/>
         <source>Distribute horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="33"/>
+        <location line="+1"/>
         <source>Distribute vertically</source>
         <translation type="unfinished"></translation>
     </message>
@@ -770,7 +753,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PageContext</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="78"/>
+        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="+62"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -778,153 +761,153 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PageView</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="488"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="+472"/>
         <source>Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="490"/>
+        <location line="+2"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="495"/>
+        <location line="+5"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="500"/>
+        <location line="+5"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="507"/>
+        <location line="+7"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="514"/>
+        <location line="+7"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="520"/>
+        <location line="+6"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="529"/>
+        <location line="+9"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="538"/>
-        <source>Raise Layer</source>
+        <location line="+9"/>
+        <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="543"/>
-        <source>Lower Layer</source>
+        <location line="+5"/>
+        <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="548"/>
+        <location line="+58"/>
+        <source>Align center horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Distribute horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Distribute vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-80"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="553"/>
+        <location line="+5"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="582"/>
+        <location line="+29"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="587"/>
+        <location line="+5"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="593"/>
+        <location line="+6"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="596"/>
+        <location line="+3"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="601"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="606"/>
+        <location line="+10"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="611"/>
+        <location line="+5"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="616"/>
-        <source>Vertical centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="621"/>
+        <location line="+10"/>
         <source>Align bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="626"/>
-        <source>Distribute horizontal space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="628"/>
-        <source>Distribute vertical space</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PenAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="338"/>
-        <source>Pen</source>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+90"/>
+        <source>Brush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="348"/>
+        <location line="+10"/>
         <source>Watercolor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="349"/>
+        <location line="+1"/>
         <source>Calligraphy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="350"/>
+        <location line="+1"/>
         <source>Crayon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="371"/>
-        <source>Pen Width</source>
+        <location line="+21"/>
+        <source>Brush size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="273"/>
+        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="+256"/>
         <source>Pencil (P)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -932,12 +915,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PickColorWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="124"/>
-        <source>Straw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="311"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="+327"/>
         <source>Color picker</source>
         <translation type="unfinished"></translation>
     </message>
@@ -945,7 +923,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PolygonSidesAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="140"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-208"/>
         <source>Sides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -953,7 +931,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PolygonTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="38"/>
+        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="+22"/>
         <source>Polygon (H)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,182 +939,183 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/service/filehander.cpp" line="103"/>
-        <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="104"/>
-        <location filename="../src/service/filehander.cpp" line="129"/>
-        <location filename="../src/service/filehander.cpp" line="203"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="813"/>
-        <location filename="../src/service/filehander.cpp" line="103"/>
-        <location filename="../src/service/filehander.cpp" line="128"/>
-        <location filename="../src/service/filehander.cpp" line="202"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-1061"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="128"/>
-        <location filename="../src/service/filehander.cpp" line="202"/>
-        <source>The file is in an older version, and the properties of elements will be changed. Proceed to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="462"/>
-        <source>Unable to save. There is not enough disk space.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="76"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="-223"/>
         <source>File not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="344"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-468"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="354"/>
-        <source>Apply to all files</source>
+        <location line="+10"/>
+        <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="357"/>
+        <location line="+3"/>
         <source>The dimensions of %1 exceed the canvas. How to display it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="811"/>
+        <location line="+453"/>
         <source>%1 has been modified in other programs. Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="812"/>
+        <location line="+1"/>
         <source>Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1357"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1745"/>
+        <location line="+556"/>
+        <location line="+427"/>
         <source>Import failed: no more than 10,000 pixels please</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="62"/>
-        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="195"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="+66"/>
+        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="+179"/>
         <source>Source Han Sans CN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="346"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="358"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-1448"/>
+        <location line="+12"/>
         <source>Keep original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="346"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="358"/>
+        <location line="-12"/>
+        <location line="+12"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="61"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="+45"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="41"/>
+        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="+25"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="168"/>
+        <location line="+127"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="13"/>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="22"/>
+        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="+17"/>
+        <location line="+11"/>
+        <location filename="../src/application.cpp" line="-331"/>
+        <location line="+8"/>
         <source>DDF Drawings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/thicknessbuttonswidget.cpp" line="50"/>
-        <source>thickness</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/example/main.cpp" line="185"/>
-        <location filename="../src/drawboard/test/main.cpp" line="150"/>
+        <location filename="../src/drawboard/example/main.cpp" line="+189"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+154"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="214"/>
-        <location filename="../src/drawboard/test/main.cpp" line="179"/>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="243"/>
-        <location filename="../src/drawboard/test/main.cpp" line="208"/>
-        <source>radius</source>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/deepin-draw/main.cpp" line="+95"/>
+        <source>The quick brown fox jumps over the lazy dog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>All work and no play makes Jack a dull boy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>To be or not to be, that is the question</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Now is the time for all good men to come to the aid of their country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The early bird catches the worm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A picture is worth a thousand words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Actions speak louder than words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Better late than never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The best way to predict the future is to create it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Knowledge is power</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RectRadiusStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="70"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="+74"/>
         <source>Rounded corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="74"/>
+        <location line="+4"/>
         <source>Same radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="83"/>
-        <source>Different radius</source>
+        <location line="+9"/>
+        <source>Different radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="121"/>
-        <source>left radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="129"/>
-        <source>right radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="137"/>
-        <source>left bottom radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="145"/>
-        <source>right bottom radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="165"/>
-        <source>radius</source>
+        <location line="+85"/>
+        <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="40"/>
+        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="+24"/>
         <source>Rectangle (R)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1144,22 +1123,22 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>RotateAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="78"/>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="+61"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="104"/>
-        <source>Flip horizontally</source>
+        <location line="+26"/>
+        <source>Flip horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="113"/>
-        <source>Flip vertically</source>
+        <location line="+9"/>
+        <source>Flip vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="202"/>
+        <location line="+90"/>
         <source>Please enter a value between -360 and 360</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1167,16 +1146,16 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>SaveTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="151"/>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="153"/>
-        <source>save</source>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-40"/>
+        <location line="+2"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SelectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="100"/>
+        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="+84"/>
         <source>Select (V)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1184,248 +1163,240 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>Shortcut</name>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="31"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="+15"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="32"/>
+        <location line="+1"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="33"/>
+        <location line="+1"/>
         <source>Shapes/Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="34"/>
+        <location line="+1"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="35"/>
+        <location line="+1"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="39"/>
+        <location line="+4"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="40"/>
+        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="41"/>
+        <location line="+1"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="42"/>
+        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="43"/>
+        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="44"/>
+        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="47"/>
+        <location line="+3"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="48"/>
+        <location line="+1"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="49"/>
+        <location line="+1"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="50"/>
+        <location line="+1"/>
         <source>Ellipse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="51"/>
+        <location line="+1"/>
         <source>Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="52"/>
+        <location line="+1"/>
         <source>Star</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="53"/>
+        <location line="+1"/>
         <source>Polygon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="54"/>
+        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="56"/>
+        <location line="+2"/>
         <source>Pencil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="55"/>
+        <location line="+18"/>
+        <source>Raise layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Align center horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Align center vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-34"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="57"/>
+        <location line="+2"/>
         <source>Eraser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="58"/>
+        <location line="+1"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="59"/>
+        <location line="+1"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="60"/>
+        <location line="+1"/>
         <source>Expand canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="61"/>
+        <location line="+1"/>
         <source>Shrink canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="66"/>
+        <location line="+5"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="67"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="68"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="69"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="70"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="71"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="72"/>
+        <location line="+1"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="73"/>
+        <location line="+1"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="74"/>
-        <source>Raise Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="75"/>
-        <source>Lower Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="76"/>
+        <location line="+3"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="77"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="81"/>
+        <location line="+4"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="82"/>
+        <location line="+1"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="84"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="85"/>
+        <location line="+1"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="86"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="87"/>
+        <location line="+2"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="88"/>
+        <location line="+1"/>
         <source>Align bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="89"/>
-        <source>Vertical centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SprayGunTool</name>
-    <message>
-        <location filename="../src/drawboard/toolplugins/sprayGunTool/sprayguntool.cpp" line="150"/>
-        <source>spray gun</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StarAnchorAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="100"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-40"/>
         <source>Vertices</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1433,7 +1404,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StarTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="39"/>
+        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="+23"/>
         <source>Star (F)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1441,7 +1412,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StartAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="120"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+20"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1449,7 +1420,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StyleAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="53"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="+57"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,12 +1428,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TabBarWgt</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="127"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="-88"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="132"/>
+        <location line="+5"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1470,17 +1441,17 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="23"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="-39"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="50"/>
+        <location line="+27"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="187"/>
+        <location line="+137"/>
         <source>Font size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1488,52 +1459,52 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="61"/>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="+45"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="62"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="63"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="64"/>
+        <location line="+1"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="65"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="66"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="67"/>
+        <location line="+1"/>
         <source>Text Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="68"/>
+        <location line="+1"/>
         <source>Text Align Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="69"/>
+        <location line="+1"/>
         <source>Text Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="70"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1541,12 +1512,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="106"/>
+        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="+90"/>
         <source>Text (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="192"/>
+        <location line="+86"/>
         <source>Input text here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1554,52 +1525,52 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TopTilte</name>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="183"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="+166"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="188"/>
+        <location line="+5"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="204"/>
+        <location line="+16"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="194"/>
+        <location line="-10"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="66"/>
+        <location line="-128"/>
         <source>Crop canvas (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="70"/>
+        <location line="+5"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="199"/>
+        <location line="+128"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="209"/>
+        <location line="+15"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="232"/>
+        <location line="+23"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="235"/>
+        <location line="+3"/>
         <source>Draw is a lightweight drawing tool for users to freely draw and simply edit images. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1607,8 +1578,16 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TriangleTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="39"/>
+        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="+23"/>
         <source>Triangle (S)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UndoTool</name>
+    <message>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-94"/>
+        <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/deepin-draw_en.ts
+++ b/translations/deepin-draw_en.ts
@@ -4,8 +4,8 @@
 <context>
     <name>AdjustmentAtrriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="39"/>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="43"/>
+        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="+39"/>
+        <location line="+4"/>
         <source>Auto fit</source>
         <translation>Auto fit</translation>
     </message>
@@ -13,20 +13,20 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../src/application.cpp" line="396"/>
+        <location filename="../src/application.cpp" line="+396"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="96"/>
-        <location filename="../src/application.cpp" line="142"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="62"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="108"/>
+        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="+62"/>
+        <location line="+46"/>
+        <location filename="../src/application.cpp" line="-300"/>
+        <location line="+46"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="395"/>
+        <location filename="../src/application.cpp" line="+253"/>
         <source>You can import up to 30 pictures, please try again!</source>
         <translation>You can import up to 30 pictures, please try again!</translation>
     </message>
@@ -34,7 +34,7 @@
 <context>
     <name>BlurAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="244"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+244"/>
         <source>Width</source>
         <translation>Width</translation>
     </message>
@@ -42,12 +42,12 @@
 <context>
     <name>BlurAttributionWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="22"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="+22"/>
         <source>Blur</source>
         <translation type="unfinished">Blur</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="23"/>
+        <location line="+1"/>
         <source>Mosaic</source>
         <translation type="unfinished">Mosaic</translation>
     </message>
@@ -55,38 +55,15 @@
 <context>
     <name>BlurTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="47"/>
+        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="+47"/>
         <source>Blur (B)</source>
         <translation>Blur (B)</translation>
     </message>
 </context>
 <context>
-    <name>BlurWidget</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="84"/>
-        <source>Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="94"/>
-        <source>Blur</source>
-        <translation type="unfinished">Blur</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="107"/>
-        <source>Mosaic</source>
-        <translation type="unfinished">Mosaic</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="130"/>
-        <source>Width</source>
-        <translation type="unfinished">Width</translation>
-    </message>
-</context>
-<context>
     <name>CAbstractProcessDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="101"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="+101"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
@@ -94,7 +71,7 @@
 <context>
     <name>CAlphaControlWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="52"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="+52"/>
         <source>Alpha</source>
         <translation>Alpha</translation>
     </message>
@@ -102,17 +79,17 @@
 <context>
     <name>CCutDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="+59"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
+        <location line="+0"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="58"/>
+        <location line="-1"/>
         <source>Do you want to save the cropped image?</source>
         <translation>Do you want to save the cropped image?</translation>
     </message>
@@ -120,458 +97,197 @@
 <context>
     <name>CCutTool</name>
     <message>
-        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="86"/>
+        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="+86"/>
         <source>Crop canvas (C)</source>
         <translation>Crop canvas (C)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ccuttool.cpp" line="74"/>
-        <source>Crop (C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CCutWidget</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="231"/>
-        <source>Dimensions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="246"/>
-        <source>x</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="296"/>
-        <source>Aspect ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="337"/>
-        <source>Free</source>
-        <translation type="unfinished">Free</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="344"/>
-        <source>Original</source>
-        <translation type="unfinished">Original</translation>
-    </message>
-</context>
-<context>
-    <name>CEllipseTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cellipsetool.cpp" line="41"/>
-        <source>Ellipse (O)</source>
-        <translation type="unfinished">Ellipse (O)</translation>
-    </message>
-</context>
-<context>
-    <name>CEraserTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="63"/>
-        <source>Eraser (E)</source>
-        <translation type="unfinished">Eraser (E)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="78"/>
-        <source>Width</source>
-        <translation type="unfinished">Width</translation>
     </message>
 </context>
 <context>
     <name>CExportImageDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="432"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="+432"/>
         <source>Percentage</source>
         <translation>Percentage</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="460"/>
+        <location line="+28"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="462"/>
+        <location line="+2"/>
         <source>Dimensions:</source>
         <translation>Dimensions:</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="471"/>
+        <location line="+9"/>
         <source>Lock aspect ratio</source>
         <translation>Lock aspect ratio</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="795"/>
+        <location line="+324"/>
         <source>It supports up to 10,000 pixels</source>
         <translation>It supports up to 10,000 pixels</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="163"/>
+        <location line="-632"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="181"/>
+        <location line="+18"/>
         <source>Pictures</source>
         <translation>Pictures</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="182"/>
+        <location line="+1"/>
         <source>Documents</source>
         <translation>Documents</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="183"/>
+        <location line="+1"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="184"/>
+        <location line="+1"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="185"/>
+        <location line="+1"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="186"/>
+        <location line="+1"/>
         <source>Music</source>
         <translation>Music</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="187"/>
+        <location line="+1"/>
         <source>Select other directories</source>
         <translation>Select other directories</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="192"/>
+        <location line="+5"/>
         <source>jpg</source>
         <translation>jpg</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="191"/>
+        <location line="-1"/>
         <source>png</source>
         <translation>png</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="193"/>
+        <location line="+2"/>
         <source>bmp</source>
         <translation>bmp</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="194"/>
+        <location line="+1"/>
         <source>tif</source>
         <translation>tif</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="195"/>
+        <location line="+1"/>
         <source>pdf</source>
         <translation>pdf</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="196"/>
+        <location line="+1"/>
         <source>ppm</source>
         <translation>ppm</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="197"/>
+        <location line="+1"/>
         <source>xbm</source>
         <translation>xbm</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="198"/>
+        <location line="+1"/>
         <source>xpm</source>
         <translation>xpm</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="230"/>
+        <location line="+32"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="231"/>
+        <location line="+1"/>
         <source>Save to:</source>
         <translation>Save to:</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="233"/>
+        <location line="+2"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="235"/>
+        <location line="+2"/>
         <source>Quality:</source>
         <translation>Quality:</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="241"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+6"/>
+        <location line="+80"/>
+        <location line="+78"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="242"/>
+        <location line="-157"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+157"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="320"/>
+        <location line="-79"/>
         <source>This file will be hidden if the file name starts with a dot (.). Do you want to hide it?</source>
         <translation>This file will be hidden if the file name starts with a dot (.). Do you want to hide it?</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
+        <location line="+1"/>
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="333"/>
+        <location line="+12"/>
         <source>The file name is too long</source>
         <translation>The file name is too long</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="397"/>
+        <location line="+64"/>
         <source>%1 
  already exists, do you want to replace it?</source>
         <translation>%1 
  already exists, do you want to replace it?</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="479"/>
+        <location line="+82"/>
         <source>W</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="495"/>
+        <location line="+16"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="793"/>
+        <location line="+298"/>
         <source>At least one pixel please</source>
         <translation>At least one pixel please</translation>
     </message>
 </context>
 <context>
-    <name>CGroupButtonWgt</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="472"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="484"/>
-        <source>Group</source>
-        <translation type="unfinished">Group</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="475"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="492"/>
-        <source>Ungroup</source>
-        <translation type="unfinished">Ungroup</translation>
-    </message>
-</context>
-<context>
-    <name>CLineTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/clinetool.cpp" line="42"/>
-        <source>Line (L)</source>
-        <translation type="unfinished">Line (L)</translation>
-    </message>
-</context>
-<context>
-    <name>CPenTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="62"/>
-        <source>Pencil (P)</source>
-        <translation type="unfinished">Pencil (P)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="79"/>
-        <source>Start</source>
-        <translation type="unfinished">Start</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="107"/>
-        <source>End</source>
-        <translation type="unfinished">End</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="150"/>
-        <source>Watercolor</source>
-        <translation type="unfinished">Watercolor</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="151"/>
-        <source>Calligraphy pen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="152"/>
-        <source>Crayon</source>
-        <translation type="unfinished">Crayon</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="497"/>
-        <source>Style</source>
-        <translation type="unfinished">Style</translation>
-    </message>
-</context>
-<context>
-    <name>CPictureTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="51"/>
-        <source>Import (I)</source>
-        <translation type="unfinished">Import (I)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="78"/>
-        <source>Rotate 90° CCW</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="96"/>
-        <source>Rotate 90° CW</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="113"/>
-        <source>Flip horizontally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="133"/>
-        <source>Flip vertically</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="152"/>
-        <source>Auto fit</source>
-        <translation type="unfinished">Auto fit</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="196"/>
-        <source>Import Picture</source>
-        <translation type="unfinished">Import Picture</translation>
-    </message>
-</context>
-<context>
-    <name>CPolygonTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="53"/>
-        <source>Polygon (H)</source>
-        <translation type="unfinished">Polygon (H)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="70"/>
-        <source>Sides</source>
-        <translation type="unfinished">Sides</translation>
-    </message>
-</context>
-<context>
-    <name>CPolygonalStarTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="33"/>
-        <source>Star (F)</source>
-        <translation type="unfinished">Star (F)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="74"/>
-        <source>Points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="81"/>
-        <source>Radius</source>
-        <translation type="unfinished">Radius</translation>
-    </message>
-</context>
-<context>
-    <name>CRectTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="52"/>
-        <source>Rectangle (R)</source>
-        <translation type="unfinished">Rectangle (R)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="120"/>
-        <source>Fill</source>
-        <translation type="unfinished">Fill</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="126"/>
-        <source>Corner Radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="257"/>
-        <source>Width</source>
-        <translation type="unfinished">Width</translation>
-    </message>
-</context>
-<context>
-    <name>CSelectTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="74"/>
-        <source>Select (V)</source>
-        <translation type="unfinished">Select (V)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="108"/>
-        <source>Unnamed</source>
-        <translation type="unfinished">Unnamed</translation>
-    </message>
-</context>
-<context>
-    <name>CTextTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="52"/>
-        <source>Color</source>
-        <translation type="unfinished">Color</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="83"/>
-        <source>Text (T)</source>
-        <translation type="unfinished">Text (T)</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="214"/>
-        <source>Input text here</source>
-        <translation type="unfinished">Input text here</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="313"/>
-        <source>Weight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="329"/>
-        <source>Font</source>
-        <translation type="unfinished">Font</translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="454"/>
-        <source>Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CTriangleTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctriangletool.cpp" line="46"/>
-        <source>Triangle (S)</source>
-        <translation type="unfinished">Triangle (S)</translation>
-    </message>
-</context>
-<context>
     <name>CloseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="176"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+176"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
@@ -579,18 +295,17 @@
 <context>
     <name>ColorPanel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="80"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="+80"/>
         <source>Color palette</source>
         <translation>Color palette</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="108"/>
-        <location filename="../src/frame/AttributesWidgets/private/colorpanel.cpp" line="159"/>
+        <location line="+28"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="208"/>
+        <location line="+100"/>
         <source>More colors</source>
         <translation>More colors</translation>
     </message>
@@ -598,12 +313,12 @@
 <context>
     <name>ColorStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="66"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="+66"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="81"/>
+        <location line="+15"/>
         <source>Fill</source>
         <translation>Fill</translation>
     </message>
@@ -611,7 +326,7 @@
 <context>
     <name>CommonAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="66"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="+66"/>
         <source>Stroke</source>
         <translation>Stroke</translation>
     </message>
@@ -619,27 +334,27 @@
 <context>
     <name>CutAttributionWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="30"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="+30"/>
         <source>Ratio</source>
         <translation>Ratio</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <location line="+32"/>
         <source>Original</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <location line="+0"/>
         <source>Free</source>
         <translation>Free</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="83"/>
+        <location line="+21"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="84"/>
+        <location line="+1"/>
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
@@ -647,32 +362,32 @@
 <context>
     <name>DataHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="82"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="109"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="126"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+82"/>
+        <location line="+27"/>
+        <location line="+17"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation>Unable to open &quot;%1&quot;, unsupported file format</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="89"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="138"/>
+        <location line="-37"/>
+        <location line="+49"/>
         <source>This file is read-only, please save with another name</source>
         <translation>This file is read-only, please save with another name</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="103"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="143"/>
+        <location line="-35"/>
+        <location line="+40"/>
         <source>The file does not exist</source>
         <translation>The file does not exist</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="115"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="133"/>
+        <location line="-28"/>
+        <location line="+18"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation>Unable to open the write-only file &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="150"/>
+        <location line="+17"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation>Unable to open the broken file &quot;%1&quot;</translation>
     </message>
@@ -680,17 +395,17 @@
 <context>
     <name>DdfHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="224"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="+224"/>
         <source>Opening...</source>
         <translation>Opening...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="256"/>
+        <location line="+32"/>
         <source>Saving...</source>
         <translation>Saving...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="302"/>
+        <location line="+46"/>
         <source>Unable to open the broken file</source>
         <translation>Unable to open the broken file</translation>
     </message>
@@ -698,7 +413,7 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_20</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="105"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="+105"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation>Unable to open the broken file &quot;%1&quot;</translation>
     </message>
@@ -706,24 +421,24 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_Compatibel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="723"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="+723"/>
         <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation>The blur effect will be lost as the file is in old version. Proceed to open it?</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <location line="+1"/>
+        <location line="+9"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <location line="-9"/>
+        <location line="+9"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="732"/>
+        <location line="-1"/>
         <source>The pen effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation>The pen effect will be lost as the file is in old version. Proceed to open it?</translation>
     </message>
@@ -731,12 +446,12 @@
 <context>
     <name>DdfUnitProccessor_chaos</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="380"/>
+        <location line="-352"/>
         <source>Saving...</source>
         <translation>Saving...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="548"/>
+        <location line="+168"/>
         <source>Unable to save. There is not enough disk space.</source>
         <translation>Unable to save. There is not enough disk space.</translation>
     </message>
@@ -744,27 +459,27 @@
 <context>
     <name>DrawBoard</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="208"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="+208"/>
         <source>The file does not exist</source>
         <translation>The file does not exist</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="220"/>
+        <location line="+12"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation>Unable to open the write-only file &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="225"/>
+        <location line="+5"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation>Unable to open &quot;%1&quot;, unsupported file format</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1874"/>
+        <location line="+1649"/>
         <source>You can import up to 30 pictures, please try again!</source>
         <translation>You can import up to 30 pictures, please try again!</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1875"/>
+        <location line="+1"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -772,26 +487,26 @@
 <context>
     <name>DrawDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="32"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="+32"/>
+        <location line="+33"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="33"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-32"/>
+        <location line="+32"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="34"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-31"/>
+        <location line="+31"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="36"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-29"/>
+        <location line="+29"/>
         <source>Save the current contents?</source>
         <translation>Save the current contents?</translation>
     </message>
@@ -799,7 +514,7 @@
 <context>
     <name>EllipseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="+25"/>
         <source>Ellipse (O)</source>
         <translation>Ellipse (O)</translation>
     </message>
@@ -807,7 +522,7 @@
 <context>
     <name>EraserAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="229"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-15"/>
         <source>Width</source>
         <translation>Width</translation>
     </message>
@@ -815,7 +530,7 @@
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="41"/>
+        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="+41"/>
         <source>Eraser (E)</source>
         <translation>Eraser (E)</translation>
     </message>
@@ -823,67 +538,43 @@
 <context>
     <name>FileHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="549"/>
-        <location filename="../src/service/filehander.cpp" line="586"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="+549"/>
         <source>Opening...</source>
         <translation>Opening...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="573"/>
-        <location filename="../src/service/filehander.cpp" line="613"/>
+        <location line="+24"/>
         <source>Saving...</source>
         <translation>Saving...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="606"/>
-        <location filename="../src/service/filehander.cpp" line="640"/>
+        <location line="+33"/>
         <source>Damaged file, unable to open it</source>
         <translation>Damaged file, unable to open it</translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="695"/>
-        <location filename="../src/service/filehander.cpp" line="835"/>
-        <source>The file does not exist</source>
-        <translation>The file does not exist</translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="676"/>
-        <location filename="../src/service/filehander.cpp" line="714"/>
+        <location line="+70"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation>Unable to open &quot;%1&quot;, unsupported file format</translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="739"/>
-        <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
-        <translation>The file name must not contain \/:*?&quot;&lt;&gt;|</translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="780"/>
-        <location filename="../src/service/filehander.cpp" line="846"/>
+        <location line="+104"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation>Unable to open the write-only file &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="793"/>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="801"/>
-        <location filename="../src/service/filehander.cpp" line="859"/>
+        <location line="+13"/>
+        <location line="+8"/>
         <source>This file is read-only, please save with another name</source>
         <translation>This file is read-only, please save with another name</translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="867"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation>You do not have permission to save files here, please change and retry</translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="822"/>
-        <location filename="../src/service/filehander.cpp" line="888"/>
+        <location line="+21"/>
         <source>The file is incompatible with the old app, please install the latest version</source>
         <translation>The file is incompatible with the old app, please install the latest version</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="838"/>
-        <location filename="../src/service/filehander.cpp" line="906"/>
+        <location line="+16"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation>Unable to open the broken file &quot;%1&quot;</translation>
     </message>
@@ -891,12 +582,12 @@
 <context>
     <name>FileSelectDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="186"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="+186"/>
         <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
         <translation>The file name must not contain \/:*?&quot;&lt;&gt;|</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="199"/>
+        <location line="+13"/>
         <source>Cannot save it as %1, since the file in that name is open now.
 Please save it in another name or close that file and try again.</source>
         <translation>Cannot save it as %1, since the file in that name is open now.
@@ -906,7 +597,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="84"/>
+        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="+84"/>
         <source>Paint bucket</source>
         <translation>Paint bucket</translation>
     </message>
@@ -914,29 +605,21 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>GroupButtonWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="22"/>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="37"/>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="+22"/>
+        <location line="+15"/>
         <source>Group</source>
         <translation>Group</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="31"/>
+        <location line="-6"/>
         <source>Ungroup</source>
         <translation>Ungroup</translation>
     </message>
 </context>
 <context>
-    <name>IBlurTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cmasicotool.cpp" line="137"/>
-        <source>Blur (B)</source>
-        <translation type="unfinished">Blur (B)</translation>
-    </message>
-</context>
-<context>
     <name>ImageHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="238"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+88"/>
         <source>Damaged file, unable to open it</source>
         <translation>Damaged file, unable to open it</translation>
     </message>
@@ -944,12 +627,12 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>ImageLoadTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="+25"/>
         <source>Import (I)</source>
         <translation>Import (I)</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="78"/>
+        <location line="+53"/>
         <source>Import Picture</source>
         <translation>Import Picture</translation>
     </message>
@@ -957,7 +640,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>LineTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="24"/>
+        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="+24"/>
         <source>Line (L)</source>
         <translation>Line (L)</translation>
     </message>
@@ -965,22 +648,22 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="131"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="+131"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
+        <location line="+108"/>
         <source>Export successful</source>
         <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
+        <location line="+0"/>
         <source>Export failed</source>
         <translation>Export failed</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="283"/>
+        <location line="+44"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
@@ -988,7 +671,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>NumberSlider</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="33"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="+33"/>
         <source>Percentage</source>
         <translation>Percentage</translation>
     </message>
@@ -996,7 +679,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>OpenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="195"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+19"/>
         <source>Import Picture</source>
         <translation>Import Picture</translation>
     </message>
@@ -1004,67 +687,67 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>OrderWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="25"/>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="+25"/>
         <source>Order</source>
         <translation>Order</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="26"/>
+        <location line="+1"/>
         <source>Raise layer</source>
         <translation>Raise layer</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="27"/>
+        <location line="+1"/>
         <source>Lower layer</source>
         <translation>Lower layer</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="28"/>
+        <location line="+1"/>
         <source>Layer to Top</source>
         <translation>Layer to Top</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="29"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation>Layer to Bottom</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="31"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation>Align left</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="32"/>
+        <location line="+1"/>
         <source>Align center horizontally</source>
         <translation>Align center horizontally</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="35"/>
+        <location line="+3"/>
         <source>Align center vertically</source>
         <translation>Align center vertically</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="33"/>
+        <location line="-2"/>
         <source>Align right</source>
         <translation>Align right</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="34"/>
+        <location line="+1"/>
         <source>Align top</source>
         <translation>Align top</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="36"/>
+        <location line="+2"/>
         <source>Align bottom</source>
         <translation>Align bottom</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="38"/>
+        <location line="+2"/>
         <source>Distribute horizontally</source>
         <translation>Distribute horizontally</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="39"/>
+        <location line="+1"/>
         <source>Distribute vertically</source>
         <translation>Distribute vertically</translation>
     </message>
@@ -1072,8 +755,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PageContext</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="62"/>
-        <location filename="../src/drawshape/cdrawparamsigleton.cpp" line="50"/>
+        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="+62"/>
         <source>Unnamed</source>
         <translation>Unnamed</translation>
     </message>
@@ -1081,215 +763,145 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PageView</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="472"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="306"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="650"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="+472"/>
         <source>Layer</source>
         <translation>Layer</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="474"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="308"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="667"/>
+        <location line="+2"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="479"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="313"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="668"/>
+        <location line="+5"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="484"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="318"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="669"/>
+        <location line="+5"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="491"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="325"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="670"/>
+        <location line="+7"/>
         <source>Select All</source>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="498"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="332"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="676"/>
+        <location line="+7"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="504"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="338"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="671"/>
+        <location line="+6"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="513"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="347"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="672"/>
+        <location line="+9"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="522"/>
+        <location line="+9"/>
         <source>Raise layer</source>
         <translation>Raise layer</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="527"/>
+        <location line="+5"/>
         <source>Lower layer</source>
         <translation>Lower layer</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="610"/>
+        <location line="+83"/>
         <source>Distribute horizontally</source>
         <translation>Distribute horizontally</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="612"/>
+        <location line="+2"/>
         <source>Distribute vertically</source>
         <translation>Distribute vertically</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="532"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="366"/>
+        <location line="-80"/>
         <source>Layer to Top</source>
         <translation>Layer to Top</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="537"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="371"/>
+        <location line="+5"/>
         <source>Layer to Bottom</source>
         <translation>Layer to Bottom</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="566"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="400"/>
+        <location line="+29"/>
         <source>Group</source>
         <translation>Group</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="571"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="405"/>
+        <location line="+5"/>
         <source>Ungroup</source>
         <translation>Ungroup</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="577"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="411"/>
+        <location line="+6"/>
         <source>Align</source>
         <translation>Align</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="580"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="414"/>
+        <location line="+3"/>
         <source>Align left</source>
         <translation>Align left</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="585"/>
+        <location line="+5"/>
         <source>Align center horizontally</source>
         <translation>Align center horizontally</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="590"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="424"/>
+        <location line="+5"/>
         <source>Align right</source>
         <translation>Align right</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="595"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="429"/>
+        <location line="+5"/>
         <source>Align top</source>
         <translation>Align top</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="600"/>
+        <location line="+5"/>
         <source>Align center vertically</source>
         <translation>Align center vertically</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="605"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="439"/>
+        <location line="+5"/>
         <source>Align bottom</source>
         <translation>Align bottom</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="356"/>
-        <source>Raise Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="361"/>
-        <source>Lower Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="419"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="434"/>
-        <source>Vertical centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="444"/>
-        <source>Distribute horizontal space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="446"/>
-        <source>Distribute vertical space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="673"/>
-        <source>Text Align Left</source>
-        <translation type="unfinished">Text Align Left</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="674"/>
-        <source>Text Align Right</source>
-        <translation type="unfinished">Text Align Right</translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="675"/>
-        <source>Text Align Center</source>
-        <translation type="unfinished">Text Align Center</translation>
     </message>
 </context>
 <context>
     <name>PenAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="319"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+90"/>
         <source>Brush</source>
         <translation>Brush</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="329"/>
+        <location line="+10"/>
         <source>Watercolor</source>
         <translation>Watercolor</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="330"/>
+        <location line="+1"/>
         <source>Calligraphy</source>
         <translation>Calligraphy</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="331"/>
+        <location line="+1"/>
         <source>Crayon</source>
         <translation>Crayon</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="352"/>
+        <location line="+21"/>
         <source>Brush size</source>
         <translation>Brush size</translation>
     </message>
@@ -1297,7 +909,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="256"/>
+        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="+256"/>
         <source>Pencil (P)</source>
         <translation>Pencil (P)</translation>
     </message>
@@ -1305,7 +917,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PickColorWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="327"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="+327"/>
         <source>Color picker</source>
         <translation>Color picker</translation>
     </message>
@@ -1313,7 +925,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PolygonSidesAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="144"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-208"/>
         <source>Sides</source>
         <translation>Sides</translation>
     </message>
@@ -1321,7 +933,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>PolygonTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="22"/>
+        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="+22"/>
         <source>Polygon (H)</source>
         <translation>Polygon (H)</translation>
     </message>
@@ -1329,205 +941,175 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="60"/>
-        <location filename="../src/frame/cviewmanagement.cpp" line="186"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="-223"/>
         <source>File not saved</source>
         <translation>File not saved</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="66"/>
-        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="179"/>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="340"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="+66"/>
+        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="+179"/>
         <source>Source Han Sans CN</source>
         <translation>Source Han Sans CN</translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="89"/>
-        <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
-        <translation>The blur effect will be lost as the file is in old version. Proceed to open it?</translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="90"/>
-        <location filename="../src/service/filehander.cpp" line="115"/>
-        <location filename="../src/service/filehander.cpp" line="189"/>
-        <source>Open</source>
-        <translation>Open</translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="814"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="386"/>
-        <location filename="../src/service/filehander.cpp" line="90"/>
-        <location filename="../src/service/filehander.cpp" line="115"/>
-        <location filename="../src/service/filehander.cpp" line="189"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-1061"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="114"/>
-        <location filename="../src/service/filehander.cpp" line="188"/>
-        <source>The file is in an older version, and the properties of elements will be changed. Proceed to open it?</source>
-        <translation>The file is in an older version, and the properties of elements will be changed. Proceed to open it?</translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="452"/>
-        <source>Unable to save. There is not enough disk space.</source>
-        <translation>Unable to save. There is not enough disk space.</translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="346"/>
+        <location line="-468"/>
         <source>Unnamed</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="359"/>
+        <location line="+13"/>
         <source>The dimensions of %1 exceed the canvas. How to display it?</source>
         <translation>The dimensions of %1 exceed the canvas. How to display it?</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
+        <location line="-11"/>
+        <location line="+12"/>
         <source>Keep original size</source>
         <translation>Keep original size</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
+        <location line="-12"/>
+        <location line="+12"/>
         <source>Auto fit</source>
         <translation>Auto fit</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="356"/>
+        <location line="-4"/>
         <source>Apply to all</source>
         <translation>Apply to all</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="812"/>
+        <location line="+456"/>
         <source>%1 has been modified in other programs. Do you want to reload it?</source>
         <translation>%1 has been modified in other programs. Do you want to reload it?</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="813"/>
+        <location line="+1"/>
         <source>Reload</source>
         <translation>Reload</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1369"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1796"/>
+        <location line="+556"/>
+        <location line="+427"/>
         <source>Import failed: no more than 10,000 pixels please</source>
         <translation>Import failed: no more than 10,000 pixels please</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="45"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="375"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="+45"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="+25"/>
         <source>Opening...</source>
         <translation>Opening...</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="152"/>
+        <location line="+127"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="64"/>
-        <location filename="../src/application.cpp" line="72"/>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="17"/>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="28"/>
+        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="+17"/>
+        <location line="+11"/>
+        <location filename="../src/application.cpp" line="-331"/>
+        <location line="+8"/>
         <source>DDF Drawings</source>
         <translation>DDF Drawings</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="189"/>
-        <location filename="../src/drawboard/test/main.cpp" line="154"/>
+        <location filename="../src/drawboard/example/main.cpp" line="+189"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+154"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="218"/>
-        <location filename="../src/drawboard/test/main.cpp" line="183"/>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
         <source>End</source>
         <translation>End</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="247"/>
-        <location filename="../src/drawboard/test/main.cpp" line="212"/>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
         <source>Radius</source>
         <translation>Radius</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="95"/>
+        <location filename="../src/deepin-draw/main.cpp" line="+95"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="96"/>
+        <location line="+1"/>
         <source>All work and no play makes Jack a dull boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="97"/>
+        <location line="+1"/>
         <source>To be or not to be, that is the question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="98"/>
+        <location line="+1"/>
         <source>Now is the time for all good men to come to the aid of their country</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="99"/>
+        <location line="+1"/>
         <source>The early bird catches the worm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="100"/>
+        <location line="+1"/>
         <source>A picture is worth a thousand words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="101"/>
+        <location line="+1"/>
         <source>Actions speak louder than words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="102"/>
+        <location line="+1"/>
         <source>Better late than never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="103"/>
-        <source>I&apos;m sorry, I don&apos;t understand</source>
+        <location line="+1"/>
+        <source>The best way to predict the future is to create it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="68"/>
-        <source>Stroke</source>
-        <translation type="unfinished">Stroke</translation>
+        <location line="+1"/>
+        <source>Knowledge is power</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RectRadiusStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="74"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="+74"/>
         <source>Rounded corners</source>
         <translation>Rounded corners</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="78"/>
+        <location line="+4"/>
         <source>Same radius</source>
         <translation>Same radius</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="87"/>
+        <location line="+9"/>
         <source>Different radii</source>
         <translation>Different radii</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="172"/>
+        <location line="+85"/>
         <source>Radius</source>
         <translation>Radius</translation>
     </message>
@@ -1535,7 +1117,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>RectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="24"/>
+        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="+24"/>
         <source>Rectangle (R)</source>
         <translation>Rectangle (R)</translation>
     </message>
@@ -1543,22 +1125,22 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>RotateAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="61"/>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="+61"/>
         <source>Rotate</source>
         <translation>Rotate</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="87"/>
+        <location line="+26"/>
         <source>Flip horizontal</source>
         <translation>Flip horizontal</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="96"/>
+        <location line="+9"/>
         <source>Flip vertical</source>
         <translation>Flip vertical</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="186"/>
+        <location line="+90"/>
         <source>Please enter a value between -360 and 360</source>
         <translation>Please enter a value between -360 and 360</translation>
     </message>
@@ -1566,8 +1148,8 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>SaveTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="155"/>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="157"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-40"/>
+        <location line="+2"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
@@ -1575,7 +1157,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>SelectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="84"/>
+        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="+84"/>
         <source>Select (V)</source>
         <translation>Select (V)</translation>
     </message>
@@ -1583,302 +1165,240 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>Shortcut</name>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="15"/>
-        <location filename="../src/utils/shortcut.cpp" line="18"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="+15"/>
         <source>Files</source>
         <translation>Files</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="16"/>
-        <location filename="../src/utils/shortcut.cpp" line="19"/>
+        <location line="+1"/>
         <source>Drawing</source>
         <translation>Drawing</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="17"/>
-        <location filename="../src/utils/shortcut.cpp" line="20"/>
+        <location line="+1"/>
         <source>Shapes/Images</source>
         <translation>Shapes/Images</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="18"/>
-        <location filename="../src/utils/shortcut.cpp" line="21"/>
+        <location line="+1"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="19"/>
-        <location filename="../src/utils/shortcut.cpp" line="22"/>
+        <location line="+1"/>
         <source>Align</source>
         <translation>Align</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="23"/>
-        <location filename="../src/utils/shortcut.cpp" line="26"/>
+        <location line="+4"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="24"/>
-        <location filename="../src/utils/shortcut.cpp" line="27"/>
+        <location line="+1"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="25"/>
-        <location filename="../src/utils/shortcut.cpp" line="28"/>
+        <location line="+1"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="26"/>
-        <location filename="../src/utils/shortcut.cpp" line="29"/>
+        <location line="+1"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="27"/>
-        <location filename="../src/utils/shortcut.cpp" line="30"/>
+        <location line="+1"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="28"/>
-        <location filename="../src/utils/shortcut.cpp" line="31"/>
+        <location line="+1"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="31"/>
-        <location filename="../src/utils/shortcut.cpp" line="34"/>
+        <location line="+3"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="32"/>
-        <location filename="../src/utils/shortcut.cpp" line="35"/>
+        <location line="+1"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="33"/>
-        <location filename="../src/utils/shortcut.cpp" line="36"/>
+        <location line="+1"/>
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="34"/>
-        <location filename="../src/utils/shortcut.cpp" line="37"/>
+        <location line="+1"/>
         <source>Ellipse</source>
         <translation>Ellipse</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="35"/>
-        <location filename="../src/utils/shortcut.cpp" line="38"/>
+        <location line="+1"/>
         <source>Triangle</source>
         <translation>Triangle</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="36"/>
-        <location filename="../src/utils/shortcut.cpp" line="39"/>
+        <location line="+1"/>
         <source>Star</source>
         <translation>Star</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="37"/>
-        <location filename="../src/utils/shortcut.cpp" line="40"/>
+        <location line="+1"/>
         <source>Polygon</source>
         <translation>Polygon</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="38"/>
-        <location filename="../src/utils/shortcut.cpp" line="41"/>
+        <location line="+1"/>
         <source>Line</source>
         <translation>Line</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="40"/>
-        <location filename="../src/utils/shortcut.cpp" line="43"/>
+        <location line="+2"/>
         <source>Pencil</source>
         <translation>Pencil</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="58"/>
+        <location line="+18"/>
         <source>Raise layer</source>
         <translation>Raise layer</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="59"/>
+        <location line="+1"/>
         <source>Lower layer</source>
         <translation>Lower layer</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="39"/>
-        <location filename="../src/utils/shortcut.cpp" line="42"/>
+        <location line="-20"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="41"/>
-        <location filename="../src/utils/shortcut.cpp" line="44"/>
+        <location line="+2"/>
         <source>Eraser</source>
         <translation>Eraser</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="42"/>
-        <location filename="../src/utils/shortcut.cpp" line="45"/>
+        <location line="+1"/>
         <source>Blur</source>
         <translation>Blur</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="43"/>
-        <location filename="../src/utils/shortcut.cpp" line="46"/>
+        <location line="+1"/>
         <source>Crop</source>
         <translation>Crop</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="44"/>
-        <location filename="../src/utils/shortcut.cpp" line="47"/>
+        <location line="+1"/>
         <source>Expand canvas</source>
         <translation>Expand canvas</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="45"/>
-        <location filename="../src/utils/shortcut.cpp" line="48"/>
+        <location line="+1"/>
         <source>Shrink canvas</source>
         <translation>Shrink canvas</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="50"/>
-        <location filename="../src/utils/shortcut.cpp" line="53"/>
+        <location line="+5"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="51"/>
-        <location filename="../src/utils/shortcut.cpp" line="54"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="52"/>
-        <location filename="../src/utils/shortcut.cpp" line="55"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="53"/>
-        <location filename="../src/utils/shortcut.cpp" line="56"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="54"/>
-        <location filename="../src/utils/shortcut.cpp" line="57"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="55"/>
-        <location filename="../src/utils/shortcut.cpp" line="58"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="56"/>
-        <location filename="../src/utils/shortcut.cpp" line="59"/>
+        <location line="+1"/>
         <source>Group</source>
         <translation>Group</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="57"/>
-        <location filename="../src/utils/shortcut.cpp" line="60"/>
+        <location line="+1"/>
         <source>Ungroup</source>
         <translation>Ungroup</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="60"/>
-        <location filename="../src/utils/shortcut.cpp" line="63"/>
+        <location line="+3"/>
         <source>Layer to Top</source>
         <translation>Layer to Top</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="61"/>
-        <location filename="../src/utils/shortcut.cpp" line="64"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation>Layer to Bottom</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="65"/>
-        <location filename="../src/utils/shortcut.cpp" line="68"/>
+        <location line="+4"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="66"/>
-        <location filename="../src/utils/shortcut.cpp" line="69"/>
+        <location line="+1"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="68"/>
-        <location filename="../src/utils/shortcut.cpp" line="71"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation>Align left</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="69"/>
-        <location filename="../src/utils/shortcut.cpp" line="72"/>
+        <location line="+1"/>
         <source>Align right</source>
         <translation>Align right</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="70"/>
+        <location line="+1"/>
         <source>Align center horizontally</source>
         <translation>Align center horizontally</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="71"/>
-        <location filename="../src/utils/shortcut.cpp" line="74"/>
+        <location line="+1"/>
         <source>Align top</source>
         <translation>Align top</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="72"/>
-        <location filename="../src/utils/shortcut.cpp" line="75"/>
+        <location line="+1"/>
         <source>Align bottom</source>
         <translation>Align bottom</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="73"/>
+        <location line="+1"/>
         <source>Align center vertically</source>
         <translation>Align center vertically</translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="61"/>
-        <source>Raise Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="62"/>
-        <source>Lower Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="73"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="76"/>
-        <source>Vertical centers</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StarAnchorAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="104"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-40"/>
         <source>Vertices</source>
         <translation>Vertices</translation>
     </message>
@@ -1886,7 +1406,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>StarTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="23"/>
+        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="+23"/>
         <source>Star (F)</source>
         <translation>Star (F)</translation>
     </message>
@@ -1894,7 +1414,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>StartAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="124"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+20"/>
         <source>Radius</source>
         <translation>Radius</translation>
     </message>
@@ -1902,7 +1422,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>StyleAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="57"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="+57"/>
         <source>Style</source>
         <translation>Style</translation>
     </message>
@@ -1910,12 +1430,12 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TabBarWgt</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="111"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="-88"/>
         <source>Close tab</source>
         <translation>Close tab</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="116"/>
+        <location line="+5"/>
         <source>Close other tabs</source>
         <translation>Close other tabs</translation>
     </message>
@@ -1923,17 +1443,17 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TextAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="27"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="-39"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="54"/>
+        <location line="+27"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="191"/>
+        <location line="+137"/>
         <source>Font size</source>
         <translation>Font size</translation>
     </message>
@@ -1941,52 +1461,52 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="45"/>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="+45"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="46"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="47"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="48"/>
+        <location line="+1"/>
         <source>Select All</source>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="49"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="50"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="51"/>
+        <location line="+1"/>
         <source>Text Align Left</source>
         <translation>Text Align Left</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="52"/>
+        <location line="+1"/>
         <source>Text Align Right</source>
         <translation>Text Align Right</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="53"/>
+        <location line="+1"/>
         <source>Text Align Center</source>
         <translation>Text Align Center</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="54"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -1994,12 +1514,12 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TextTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="90"/>
+        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="+90"/>
         <source>Text (T)</source>
         <translation>Text (T)</translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="176"/>
+        <location line="+86"/>
         <source>Input text here</source>
         <translation>Input text here</translation>
     </message>
@@ -2007,52 +1527,52 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TopTilte</name>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="166"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="+166"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="171"/>
+        <location line="+5"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="187"/>
+        <location line="+16"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="177"/>
+        <location line="-10"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="49"/>
+        <location line="-128"/>
         <source>Crop canvas (C)</source>
         <translation>Crop canvas (C)</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="54"/>
+        <location line="+5"/>
         <source>Unnamed</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="182"/>
+        <location line="+128"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="197"/>
+        <location line="+15"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="220"/>
+        <location line="+23"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="223"/>
+        <location line="+3"/>
         <source>Draw is a lightweight drawing tool for users to freely draw and simply edit images. </source>
         <translation>Draw is a lightweight drawing tool for users to freely draw and simply edit images. </translation>
     </message>
@@ -2060,7 +1580,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>TriangleTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="23"/>
+        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="+23"/>
         <source>Triangle (S)</source>
         <translation>Triangle (S)</translation>
     </message>
@@ -2068,7 +1588,7 @@ Please save it in another name or close that file and try again.</translation>
 <context>
     <name>UndoTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="63"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-94"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>

--- a/translations/deepin-draw_en_US.ts
+++ b/translations/deepin-draw_en_US.ts
@@ -4,8 +4,8 @@
 <context>
     <name>AdjustmentAtrriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="39"/>
-        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="43"/>
+        <location filename="../src/deepin-draw/attribution/adjustmentatrriwidget.cpp" line="+39"/>
+        <location line="+4"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13,20 +13,20 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../src/application.cpp" line="396"/>
+        <location filename="../src/application.cpp" line="+396"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="96"/>
-        <location filename="../src/application.cpp" line="142"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="62"/>
-        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="108"/>
+        <location filename="../src/deepin-draw/drawfiles/application.cpp" line="+62"/>
+        <location line="+46"/>
+        <location filename="../src/application.cpp" line="-300"/>
+        <location line="+46"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="395"/>
+        <location filename="../src/application.cpp" line="+253"/>
         <source>You can import up to 30 pictures, please try again!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
 <context>
     <name>BlurAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="244"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+244"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -42,12 +42,12 @@
 <context>
     <name>BlurAttributionWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="22"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="+22"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/blurattributionwidget.cpp" line="23"/>
+        <location line="+1"/>
         <source>Mosaic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,38 +55,15 @@
 <context>
     <name>BlurTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="47"/>
+        <location filename="../src/drawboard/drawboard/drawtools/blurtool.cpp" line="+47"/>
         <source>Blur (B)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>BlurWidget</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="84"/>
-        <source>Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="94"/>
-        <source>Blur</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="107"/>
-        <source>Mosaic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/blurwidget.cpp" line="130"/>
-        <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CAbstractProcessDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="101"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cprogressdialog.cpp" line="+101"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
@@ -94,7 +71,7 @@
 <context>
     <name>CAlphaControlWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="52"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/calphacontrolwidget.cpp" line="+52"/>
         <source>Alpha</source>
         <translation type="unfinished"></translation>
     </message>
@@ -102,17 +79,17 @@
 <context>
     <name>CCutDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="+59"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="59"/>
+        <location line="+0"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/ccutdialog.cpp" line="58"/>
+        <location line="-1"/>
         <source>Do you want to save the cropped image?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,457 +97,196 @@
 <context>
     <name>CCutTool</name>
     <message>
-        <location filename="../src/drawshape/drawTools/ccuttool.cpp" line="74"/>
-        <source>Crop (C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="86"/>
+        <location filename="../src/deepin-draw/drawtools/ccuttool.cpp" line="+86"/>
         <source>Crop canvas (C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CCutWidget</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="231"/>
-        <source>Dimensions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="246"/>
-        <source>x</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="296"/>
-        <source>Aspect ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="337"/>
-        <source>Free</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="344"/>
-        <source>Original</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CEllipseTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cellipsetool.cpp" line="41"/>
-        <source>Ellipse (O)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CEraserTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="63"/>
-        <source>Eraser (E)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cerasertool.cpp" line="78"/>
-        <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CExportImageDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="432"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="+432"/>
         <source>Percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="460"/>
+        <location line="+28"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="462"/>
+        <location line="+2"/>
         <source>Dimensions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="471"/>
+        <location line="+9"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="795"/>
+        <location line="+324"/>
         <source>It supports up to 10,000 pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="163"/>
+        <location line="-632"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="181"/>
+        <location line="+18"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="182"/>
+        <location line="+1"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="183"/>
+        <location line="+1"/>
         <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="184"/>
+        <location line="+1"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="185"/>
+        <location line="+1"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="186"/>
+        <location line="+1"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="187"/>
+        <location line="+1"/>
         <source>Select other directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="191"/>
+        <location line="+4"/>
         <source>png</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="192"/>
+        <location line="+1"/>
         <source>jpg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="193"/>
+        <location line="+1"/>
         <source>bmp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="194"/>
+        <location line="+1"/>
         <source>tif</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="195"/>
+        <location line="+1"/>
         <source>pdf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="196"/>
+        <location line="+1"/>
         <source>ppm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="197"/>
+        <location line="+1"/>
         <source>xbm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="198"/>
+        <location line="+1"/>
         <source>xpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="230"/>
+        <location line="+32"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="231"/>
+        <location line="+1"/>
         <source>Save to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="233"/>
+        <location line="+2"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="235"/>
+        <location line="+2"/>
         <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="241"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+6"/>
+        <location line="+80"/>
+        <location line="+78"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="242"/>
+        <location line="-157"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="399"/>
+        <location line="+157"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="320"/>
+        <location line="-79"/>
         <source>This file will be hidden if the file name starts with a dot (.). Do you want to hide it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="321"/>
+        <location line="+1"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="333"/>
+        <location line="+12"/>
         <source>The file name is too long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="397"/>
+        <location line="+64"/>
         <source>%1 
  already exists, do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="479"/>
+        <location line="+82"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="495"/>
+        <location line="+16"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/cexportimagedialog.cpp" line="793"/>
+        <location line="+298"/>
         <source>At least one pixel please</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CGroupButtonWgt</name>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="472"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="484"/>
-        <source>Group</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="475"/>
-        <location filename="../src/frame/AttributesWidgets/private/cattributeitemwidget.cpp" line="492"/>
-        <source>Ungroup</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CLineTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/clinetool.cpp" line="42"/>
-        <source>Line (L)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CPenTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="62"/>
-        <source>Pencil (P)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="79"/>
-        <source>Start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="107"/>
-        <source>End</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="150"/>
-        <source>Watercolor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="151"/>
-        <source>Calligraphy pen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="152"/>
-        <source>Crayon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpentool.cpp" line="497"/>
-        <source>Style</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CPictureTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="51"/>
-        <source>Import (I)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="78"/>
-        <source>Rotate 90° CCW</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="96"/>
-        <source>Rotate 90° CW</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="113"/>
-        <source>Flip horizontally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="133"/>
-        <source>Flip vertically</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="152"/>
-        <source>Auto fit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpicturetool.cpp" line="196"/>
-        <source>Import Picture</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CPolygonTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="53"/>
-        <source>Polygon (H)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygontool.cpp" line="70"/>
-        <source>Sides</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CPolygonalStarTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="33"/>
-        <source>Star (F)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="74"/>
-        <source>Points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cpolygonalstartool.cpp" line="81"/>
-        <source>Radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CRectTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="52"/>
-        <source>Rectangle (R)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="120"/>
-        <source>Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="126"/>
-        <source>Corner Radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="257"/>
-        <source>Width</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CSelectTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="74"/>
-        <source>Select (V)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/cselecttool.cpp" line="108"/>
-        <source>Unnamed</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CTextTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="52"/>
-        <source>Color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="83"/>
-        <source>Text (T)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="214"/>
-        <source>Input text here</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="313"/>
-        <source>Weight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="329"/>
-        <source>Font</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="454"/>
-        <source>Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CTriangleTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/ctriangletool.cpp" line="46"/>
-        <source>Triangle (S)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CloseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="176"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+176"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -578,18 +294,17 @@
 <context>
     <name>ColorPanel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="80"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="+80"/>
         <source>Color palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="108"/>
-        <location filename="../src/frame/AttributesWidgets/private/colorpanel.cpp" line="159"/>
+        <location line="+28"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/ccolorpanel.cpp" line="208"/>
+        <location line="+100"/>
         <source>More colors</source>
         <translation type="unfinished"></translation>
     </message>
@@ -597,12 +312,12 @@
 <context>
     <name>ColorStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="66"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="+66"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/colorstylewidget.cpp" line="81"/>
+        <location line="+15"/>
         <source>Fill</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,7 +325,7 @@
 <context>
     <name>CommonAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="66"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/commonattributionregister.cpp" line="+66"/>
         <source>Stroke</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,27 +333,27 @@
 <context>
     <name>CutAttributionWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="30"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="+30"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <location line="+32"/>
         <source>Original</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="62"/>
+        <location line="+0"/>
         <source>Free</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="83"/>
+        <location line="+21"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/cutattributionwidget.cpp" line="84"/>
+        <location line="+1"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -646,32 +361,32 @@
 <context>
     <name>DataHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="82"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="109"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="126"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+82"/>
+        <location line="+27"/>
+        <location line="+17"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="89"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="138"/>
+        <location line="-37"/>
+        <location line="+49"/>
         <source>This file is read-only, please save with another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="103"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="143"/>
+        <location line="-35"/>
+        <location line="+40"/>
         <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="115"/>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="133"/>
+        <location line="-28"/>
+        <location line="+18"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="150"/>
+        <location line="+17"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,17 +394,17 @@
 <context>
     <name>DdfHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="224"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="+224"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="256"/>
+        <location line="+32"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfhander.cpp" line="302"/>
+        <location line="+46"/>
         <source>Unable to open the broken file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -697,7 +412,7 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_20</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="105"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor_5_8_0_20.cpp" line="+105"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -705,24 +420,24 @@
 <context>
     <name>DdfUnitProccessor_5_8_0_Compatibel</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="723"/>
+        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="+723"/>
         <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <location line="+1"/>
+        <location line="+9"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="724"/>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="733"/>
+        <location line="-9"/>
+        <location line="+9"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="732"/>
+        <location line="-1"/>
         <source>The pen effect will be lost as the file is in old version. Proceed to open it?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -730,12 +445,12 @@
 <context>
     <name>DdfUnitProccessor_chaos</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="380"/>
+        <location line="-352"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/ddfHander/ddfProcessor/ddfproccessor.cpp" line="548"/>
+        <location line="+168"/>
         <source>Unable to save. There is not enough disk space.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -743,27 +458,27 @@
 <context>
     <name>DrawBoard</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="208"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="+208"/>
         <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="220"/>
+        <location line="+12"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="225"/>
+        <location line="+5"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1874"/>
+        <location line="+1649"/>
         <source>You can import up to 30 pictures, please try again!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1875"/>
+        <location line="+1"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -771,26 +486,26 @@
 <context>
     <name>DrawDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="32"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="+32"/>
+        <location line="+33"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="33"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-32"/>
+        <location line="+32"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="34"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-31"/>
+        <location line="+31"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="36"/>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/drawdialog.cpp" line="65"/>
+        <location line="-29"/>
+        <location line="+29"/>
         <source>Save the current contents?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -798,7 +513,7 @@
 <context>
     <name>EllipseTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/drawtools/ellipsetool.cpp" line="+25"/>
         <source>Ellipse (O)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -806,7 +521,7 @@
 <context>
     <name>EraserAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="229"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-15"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,7 +529,7 @@
 <context>
     <name>EraserTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="41"/>
+        <location filename="../src/drawboard/drawboard/drawtools/erasertool.cpp" line="+41"/>
         <source>Eraser (E)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,67 +537,43 @@
 <context>
     <name>FileHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="549"/>
-        <location filename="../src/service/filehander.cpp" line="586"/>
+        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="+549"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="573"/>
-        <location filename="../src/service/filehander.cpp" line="613"/>
+        <location line="+24"/>
         <source>Saving...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="606"/>
-        <location filename="../src/service/filehander.cpp" line="640"/>
+        <location line="+33"/>
         <source>Damaged file, unable to open it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="695"/>
-        <location filename="../src/service/filehander.cpp" line="835"/>
-        <source>The file does not exist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="676"/>
-        <location filename="../src/service/filehander.cpp" line="714"/>
+        <location line="+70"/>
         <source>Unable to open &quot;%1&quot;, unsupported file format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="739"/>
-        <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="780"/>
-        <location filename="../src/service/filehander.cpp" line="846"/>
+        <location line="+104"/>
         <source>Unable to open the write-only file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="793"/>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="801"/>
-        <location filename="../src/service/filehander.cpp" line="859"/>
+        <location line="+13"/>
+        <location line="+8"/>
         <source>This file is read-only, please save with another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="867"/>
-        <source>You do not have permission to save files here, please change and retry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="822"/>
-        <location filename="../src/service/filehander.cpp" line="888"/>
+        <location line="+21"/>
         <source>The file is incompatible with the old app, please install the latest version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/DataHanderInterface.cpp" line="838"/>
-        <location filename="../src/service/filehander.cpp" line="906"/>
+        <location line="+16"/>
         <source>Unable to open the broken file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -890,12 +581,12 @@
 <context>
     <name>FileSelectDialog</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="186"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="+186"/>
         <source>The file name must not contain \/:*?&quot;&lt;&gt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="199"/>
+        <location line="+13"/>
         <source>Cannot save it as %1, since the file in that name is open now.
 Please save it in another name or close that file and try again.</source>
         <translation type="unfinished"></translation>
@@ -904,7 +595,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>FillTool</name>
     <message>
-        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="84"/>
+        <location filename="../src/drawboard/toolplugins/fillTool/cfilltool.cpp" line="+84"/>
         <source>Paint bucket</source>
         <translation type="unfinished"></translation>
     </message>
@@ -912,29 +603,21 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>GroupButtonWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="22"/>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="37"/>
+        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="+22"/>
+        <location line="+15"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/groupbuttonwidget.cpp" line="31"/>
+        <location line="-6"/>
         <source>Ungroup</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>IBlurTool</name>
-    <message>
-        <location filename="../src/drawshape/drawTools/cmasicotool.cpp" line="137"/>
-        <source>Blur (B)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageHander</name>
     <message>
-        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="238"/>
+        <location filename="../src/drawboard/drawboard/dataHander/datahander.cpp" line="+88"/>
         <source>Damaged file, unable to open it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -942,12 +625,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>ImageLoadTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="+25"/>
         <source>Import (I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/imageloadtool.cpp" line="78"/>
+        <location line="+53"/>
         <source>Import Picture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -955,7 +638,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>LineTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="24"/>
+        <location filename="../src/drawboard/drawboard/drawtools/linetool.cpp" line="+24"/>
         <source>Line (L)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -963,22 +646,22 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="131"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="+131"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
+        <location line="+108"/>
         <source>Export successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="239"/>
+        <location line="+0"/>
         <source>Export failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="283"/>
+        <location line="+44"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -986,7 +669,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>NumberSlider</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="33"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cnumbersliderwidget.cpp" line="+33"/>
         <source>Percentage</source>
         <translation type="unfinished"></translation>
     </message>
@@ -994,7 +677,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>OpenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="195"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="+19"/>
         <source>Import Picture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1002,67 +685,67 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>OrderWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="25"/>
+        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="+25"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="26"/>
+        <location line="+1"/>
         <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="27"/>
+        <location line="+1"/>
         <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="28"/>
+        <location line="+1"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="29"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="31"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="32"/>
+        <location line="+1"/>
         <source>Align center horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="33"/>
+        <location line="+1"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="34"/>
+        <location line="+1"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="35"/>
+        <location line="+1"/>
         <source>Align center vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="36"/>
+        <location line="+1"/>
         <source>Align bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="38"/>
+        <location line="+2"/>
         <source>Distribute horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/orderwidget.cpp" line="39"/>
+        <location line="+1"/>
         <source>Distribute vertically</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1070,8 +753,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PageContext</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="62"/>
-        <location filename="../src/drawshape/cdrawparamsigleton.cpp" line="50"/>
+        <location filename="../src/drawboard/drawboard/drawboard/context/pagecontext.cpp" line="+62"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1079,215 +761,145 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PageView</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="472"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="306"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="650"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="+472"/>
         <source>Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="474"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="308"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="667"/>
+        <location line="+2"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="479"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="313"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="668"/>
+        <location line="+5"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="484"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="318"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="669"/>
+        <location line="+5"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="491"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="325"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="670"/>
+        <location line="+7"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="498"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="332"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="676"/>
+        <location line="+7"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="504"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="338"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="671"/>
+        <location line="+6"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="513"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="347"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="672"/>
+        <location line="+9"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="522"/>
+        <location line="+9"/>
         <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="527"/>
+        <location line="+5"/>
         <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="585"/>
+        <location line="+58"/>
         <source>Align center horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="600"/>
+        <location line="+15"/>
         <source>Align center vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="610"/>
+        <location line="+10"/>
         <source>Distribute horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="612"/>
+        <location line="+2"/>
         <source>Distribute vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="356"/>
-        <source>Raise Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="361"/>
-        <source>Lower Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="532"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="366"/>
+        <location line="-80"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="537"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="371"/>
+        <location line="+5"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="566"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="400"/>
+        <location line="+29"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="571"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="405"/>
+        <location line="+5"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="577"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="411"/>
+        <location line="+6"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="580"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="414"/>
+        <location line="+3"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="419"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="590"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="424"/>
+        <location line="+10"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="595"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="429"/>
+        <location line="+5"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="434"/>
-        <source>Vertical centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/pageview.cpp" line="605"/>
-        <location filename="../src/frame/cgraphicsview.cpp" line="439"/>
+        <location line="+10"/>
         <source>Align bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="444"/>
-        <source>Distribute horizontal space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="446"/>
-        <source>Distribute vertical space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="673"/>
-        <source>Text Align Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="674"/>
-        <source>Text Align Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/frame/cgraphicsview.cpp" line="675"/>
-        <source>Text Align Center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PenAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="319"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+90"/>
         <source>Brush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="329"/>
+        <location line="+10"/>
         <source>Watercolor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="330"/>
+        <location line="+1"/>
         <source>Calligraphy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="331"/>
+        <location line="+1"/>
         <source>Crayon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="352"/>
+        <location line="+21"/>
         <source>Brush size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1295,7 +907,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PenTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="256"/>
+        <location filename="../src/drawboard/drawboard/drawtools/pentool.cpp" line="+256"/>
         <source>Pencil (P)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1303,7 +915,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PickColorWidget</name>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="327"/>
+        <location filename="../src/drawboard/drawboard/widgets/colorWidget/private/cpickcolorwidget.cpp" line="+327"/>
         <source>Color picker</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1311,7 +923,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PolygonSidesAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="144"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-208"/>
         <source>Sides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1319,7 +931,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>PolygonTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="22"/>
+        <location filename="../src/drawboard/drawboard/drawtools/polygontool.cpp" line="+22"/>
         <source>Polygon (H)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1327,182 +939,152 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/service/filehander.cpp" line="89"/>
-        <source>The blur effect will be lost as the file is in old version. Proceed to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="90"/>
-        <location filename="../src/service/filehander.cpp" line="115"/>
-        <location filename="../src/service/filehander.cpp" line="189"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="814"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="386"/>
-        <location filename="../src/service/filehander.cpp" line="90"/>
-        <location filename="../src/service/filehander.cpp" line="115"/>
-        <location filename="../src/service/filehander.cpp" line="189"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-1061"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/service/filehander.cpp" line="114"/>
-        <location filename="../src/service/filehander.cpp" line="188"/>
-        <source>The file is in an older version, and the properties of elements will be changed. Proceed to open it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/service/filehander.cpp" line="452"/>
-        <source>Unable to save. There is not enough disk space.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="60"/>
-        <location filename="../src/frame/cviewmanagement.cpp" line="186"/>
+        <location filename="../src/deepin-draw/drawfiles/mainwindow.cpp" line="-223"/>
         <source>File not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="346"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-468"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="356"/>
+        <location line="+10"/>
         <source>Apply to all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="359"/>
+        <location line="+3"/>
         <source>The dimensions of %1 exceed the canvas. How to display it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="812"/>
+        <location line="+453"/>
         <source>%1 has been modified in other programs. Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="813"/>
+        <location line="+1"/>
         <source>Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1369"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="1796"/>
+        <location line="+556"/>
+        <location line="+427"/>
         <source>Import failed: no more than 10,000 pixels please</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="66"/>
-        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="179"/>
-        <location filename="../src/drawshape/drawTools/ctexttool.cpp" line="340"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="+66"/>
+        <location filename="../src/drawboard/drawboard/utils/global.cpp" line="+179"/>
         <source>Source Han Sans CN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawshape/drawTools/crecttool.cpp" line="68"/>
-        <source>Stroke</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="-1448"/>
+        <location line="+12"/>
         <source>Keep original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="348"/>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboard.cpp" line="360"/>
+        <location line="-12"/>
+        <location line="+12"/>
         <source>Auto fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="45"/>
-        <location filename="../src/frame/AttributesWidgets/private/ccutwidget.cpp" line="375"/>
+        <location filename="../src/drawboard/drawboard/widgets/dialog/dialog.h" line="+45"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="25"/>
+        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="+25"/>
         <source>Opening...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/widgets/progresslayout.cpp" line="152"/>
+        <location line="+127"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/application.cpp" line="64"/>
-        <location filename="../src/application.cpp" line="72"/>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="17"/>
-        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="28"/>
+        <location filename="../src/drawboard/drawboard/utils/setting.cpp" line="+17"/>
+        <location line="+11"/>
+        <location filename="../src/application.cpp" line="-331"/>
+        <location line="+8"/>
         <source>DDF Drawings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="95"/>
+        <location filename="../src/deepin-draw/main.cpp" line="+95"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="96"/>
+        <location line="+1"/>
         <source>All work and no play makes Jack a dull boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="97"/>
+        <location line="+1"/>
         <source>To be or not to be, that is the question</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="98"/>
+        <location line="+1"/>
         <source>Now is the time for all good men to come to the aid of their country</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="99"/>
+        <location line="+1"/>
         <source>The early bird catches the worm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="100"/>
+        <location line="+1"/>
         <source>A picture is worth a thousand words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="101"/>
+        <location line="+1"/>
         <source>Actions speak louder than words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="102"/>
+        <location line="+1"/>
         <source>Better late than never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/main.cpp" line="103"/>
-        <source>I&apos;m sorry, I don&apos;t understand</source>
+        <location line="+1"/>
+        <source>The best way to predict the future is to create it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="189"/>
-        <location filename="../src/drawboard/test/main.cpp" line="154"/>
+        <location line="+1"/>
+        <source>Knowledge is power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/drawboard/example/main.cpp" line="+189"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+154"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="218"/>
-        <location filename="../src/drawboard/test/main.cpp" line="183"/>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/example/main.cpp" line="247"/>
-        <location filename="../src/drawboard/test/main.cpp" line="212"/>
+        <location line="+29"/>
+        <location filename="../src/drawboard/test/main.cpp" line="+29"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1510,22 +1092,22 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>RectRadiusStyleWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="74"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="+74"/>
         <source>Rounded corners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="78"/>
+        <location line="+4"/>
         <source>Same radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="87"/>
+        <location line="+9"/>
         <source>Different radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/rectradiusstylewidget.cpp" line="172"/>
+        <location line="+85"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1533,7 +1115,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>RectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="24"/>
+        <location filename="../src/drawboard/drawboard/drawtools/recttool.cpp" line="+24"/>
         <source>Rectangle (R)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1541,22 +1123,22 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>RotateAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="61"/>
+        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="+61"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="87"/>
+        <location line="+26"/>
         <source>Flip horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="96"/>
+        <location line="+9"/>
         <source>Flip vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/rotateattriwidget.cpp" line="186"/>
+        <location line="+90"/>
         <source>Please enter a value between -360 and 360</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1564,8 +1146,8 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>SaveTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="155"/>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="157"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-40"/>
+        <location line="+2"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1573,7 +1155,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>SelectTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="84"/>
+        <location filename="../src/drawboard/drawboard/drawtools/selecttool.cpp" line="+84"/>
         <source>Select (V)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1581,302 +1163,240 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>Shortcut</name>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="15"/>
-        <location filename="../src/utils/shortcut.cpp" line="18"/>
+        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="+15"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="16"/>
-        <location filename="../src/utils/shortcut.cpp" line="19"/>
+        <location line="+1"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="17"/>
-        <location filename="../src/utils/shortcut.cpp" line="20"/>
+        <location line="+1"/>
         <source>Shapes/Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="18"/>
-        <location filename="../src/utils/shortcut.cpp" line="21"/>
+        <location line="+1"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="19"/>
-        <location filename="../src/utils/shortcut.cpp" line="22"/>
+        <location line="+1"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="23"/>
-        <location filename="../src/utils/shortcut.cpp" line="26"/>
+        <location line="+4"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="24"/>
-        <location filename="../src/utils/shortcut.cpp" line="27"/>
+        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="25"/>
-        <location filename="../src/utils/shortcut.cpp" line="28"/>
+        <location line="+1"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="26"/>
-        <location filename="../src/utils/shortcut.cpp" line="29"/>
+        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="27"/>
-        <location filename="../src/utils/shortcut.cpp" line="30"/>
+        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="28"/>
-        <location filename="../src/utils/shortcut.cpp" line="31"/>
+        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="31"/>
-        <location filename="../src/utils/shortcut.cpp" line="34"/>
+        <location line="+3"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="32"/>
-        <location filename="../src/utils/shortcut.cpp" line="35"/>
+        <location line="+1"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="33"/>
-        <location filename="../src/utils/shortcut.cpp" line="36"/>
+        <location line="+1"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="34"/>
-        <location filename="../src/utils/shortcut.cpp" line="37"/>
+        <location line="+1"/>
         <source>Ellipse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="35"/>
-        <location filename="../src/utils/shortcut.cpp" line="38"/>
+        <location line="+1"/>
         <source>Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="36"/>
-        <location filename="../src/utils/shortcut.cpp" line="39"/>
+        <location line="+1"/>
         <source>Star</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="37"/>
-        <location filename="../src/utils/shortcut.cpp" line="40"/>
+        <location line="+1"/>
         <source>Polygon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="38"/>
-        <location filename="../src/utils/shortcut.cpp" line="41"/>
+        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="40"/>
-        <location filename="../src/utils/shortcut.cpp" line="43"/>
+        <location line="+2"/>
         <source>Pencil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="58"/>
+        <location line="+18"/>
         <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="59"/>
+        <location line="+1"/>
         <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="70"/>
+        <location line="+11"/>
         <source>Align center horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="73"/>
+        <location line="+3"/>
         <source>Align center vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="39"/>
-        <location filename="../src/utils/shortcut.cpp" line="42"/>
+        <location line="-34"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="41"/>
-        <location filename="../src/utils/shortcut.cpp" line="44"/>
+        <location line="+2"/>
         <source>Eraser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="42"/>
-        <location filename="../src/utils/shortcut.cpp" line="45"/>
+        <location line="+1"/>
         <source>Blur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="43"/>
-        <location filename="../src/utils/shortcut.cpp" line="46"/>
+        <location line="+1"/>
         <source>Crop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="44"/>
-        <location filename="../src/utils/shortcut.cpp" line="47"/>
+        <location line="+1"/>
         <source>Expand canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="45"/>
-        <location filename="../src/utils/shortcut.cpp" line="48"/>
+        <location line="+1"/>
         <source>Shrink canvas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="50"/>
-        <location filename="../src/utils/shortcut.cpp" line="53"/>
+        <location line="+5"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="51"/>
-        <location filename="../src/utils/shortcut.cpp" line="54"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="52"/>
-        <location filename="../src/utils/shortcut.cpp" line="55"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="53"/>
-        <location filename="../src/utils/shortcut.cpp" line="56"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="54"/>
-        <location filename="../src/utils/shortcut.cpp" line="57"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="55"/>
-        <location filename="../src/utils/shortcut.cpp" line="58"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="56"/>
-        <location filename="../src/utils/shortcut.cpp" line="59"/>
+        <location line="+1"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="57"/>
-        <location filename="../src/utils/shortcut.cpp" line="60"/>
+        <location line="+1"/>
         <source>Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="61"/>
-        <source>Raise Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="62"/>
-        <source>Lower Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="60"/>
-        <location filename="../src/utils/shortcut.cpp" line="63"/>
+        <location line="+3"/>
         <source>Layer to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="61"/>
-        <location filename="../src/utils/shortcut.cpp" line="64"/>
+        <location line="+1"/>
         <source>Layer to Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="65"/>
-        <location filename="../src/utils/shortcut.cpp" line="68"/>
+        <location line="+4"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="66"/>
-        <location filename="../src/utils/shortcut.cpp" line="69"/>
+        <location line="+1"/>
         <source>Display shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="68"/>
-        <location filename="../src/utils/shortcut.cpp" line="71"/>
+        <location line="+2"/>
         <source>Align left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="69"/>
-        <location filename="../src/utils/shortcut.cpp" line="72"/>
+        <location line="+1"/>
         <source>Align right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/utils/shortcut.cpp" line="73"/>
-        <source>Horizontal centers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="71"/>
-        <location filename="../src/utils/shortcut.cpp" line="74"/>
+        <location line="+2"/>
         <source>Align top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/utils/shortcut.cpp" line="72"/>
-        <location filename="../src/utils/shortcut.cpp" line="75"/>
+        <location line="+1"/>
         <source>Align bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/utils/shortcut.cpp" line="76"/>
-        <source>Vertical centers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StarAnchorAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="104"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="-40"/>
         <source>Vertices</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1884,7 +1404,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StarTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="23"/>
+        <location filename="../src/drawboard/drawboard/drawtools/startool.cpp" line="+23"/>
         <source>Star (F)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1892,7 +1412,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StartAttriRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="124"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/itemstyleregisters.cpp" line="+20"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1900,7 +1420,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>StyleAttriWidget</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="57"/>
+        <location filename="../src/deepin-draw/attribution/stylewidgets/styleattriwidget.cpp" line="+57"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1908,12 +1428,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TabBarWgt</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="111"/>
+        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="-88"/>
         <source>Close tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawboard/gui/drawboardtab.cpp" line="116"/>
+        <location line="+5"/>
         <source>Close other tabs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1921,17 +1441,17 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextAttributionRegister</name>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="27"/>
+        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="-39"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="54"/>
+        <location line="+27"/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/attribution/attrbuionregisters/textattributionregister.cpp" line="191"/>
+        <location line="+137"/>
         <source>Font size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1939,52 +1459,52 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="45"/>
+        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="+45"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="46"/>
+        <location line="+1"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="47"/>
+        <location line="+1"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="48"/>
+        <location line="+1"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="49"/>
+        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="50"/>
+        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="51"/>
+        <location line="+1"/>
         <source>Text Align Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="52"/>
+        <location line="+1"/>
         <source>Text Align Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="53"/>
+        <location line="+1"/>
         <source>Text Align Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawItems/items/commonItems/ctextedit.cpp" line="54"/>
+        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1992,12 +1512,12 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TextTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="90"/>
+        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="+90"/>
         <source>Text (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/texttool.cpp" line="176"/>
+        <location line="+86"/>
         <source>Input text here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2005,52 +1525,52 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TopTilte</name>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="166"/>
+        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="+166"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="171"/>
+        <location line="+5"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="187"/>
+        <location line="+16"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="177"/>
+        <location line="-10"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="49"/>
+        <location line="-128"/>
         <source>Crop canvas (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="54"/>
+        <location line="+5"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="182"/>
+        <location line="+128"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="197"/>
+        <location line="+15"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="220"/>
+        <location line="+23"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/deepin-draw/widgets/toptoolbar.cpp" line="223"/>
+        <location line="+3"/>
         <source>Draw is a lightweight drawing tool for users to freely draw and simply edit images. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2058,7 +1578,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>TriangleTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="23"/>
+        <location filename="../src/drawboard/drawboard/drawtools/triangletool.cpp" line="+23"/>
         <source>Triangle (S)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2066,7 +1586,7 @@ Please save it in another name or close that file and try again.</source>
 <context>
     <name>UndoTool</name>
     <message>
-        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="63"/>
+        <location filename="../src/drawboard/drawboard/drawtools/buttontool.cpp" line="-94"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
## Summary by Sourcery

Clean up and update translation files and sample log messages to resolve CI issues

Bug Fixes:
- Fix CI failures by updating translation TS file entry locations to relative line offsets and removing obsolete contexts

Enhancements:
- Update sample qWarning messages in `main.cpp`, replacing the old fallback phrase with two new lines for consistency

Chores:
- Clean up and restructure `.ts` translation files by migrating to `line='+n'` offsets and removing outdated entries