### PR TITLE
fix: Failed to save the new file

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     Draw for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.21) unstable; urgency=medium
+
+  * fix: Failed to save the new file
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 03 Jul 2025 15:26:08 +0800
+
 deepin-draw (6.5.20) unstable; urgency=medium
 
   * chore: Update deb sources for linglong yaml

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     Draw for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     Draw for deepin os.

--- a/src/frame/cmultiptabbarwidget.cpp
+++ b/src/frame/cmultiptabbarwidget.cpp
@@ -220,7 +220,7 @@ begin:
     if (ret != QDialog::Rejected) {
         QStringList selectedFiles = this->selectedFiles();
         if (!selectedFiles.isEmpty()) {
-            QString path = selectedFiles.first();
+            QString path = checkAndBuildPath(selectedFiles.first());
             qDebug() << "Selected file path:" << path;
             if (!FileHander::isLegalFile(path)) {
                 qWarning() << "Invalid file name:" << path;
@@ -280,3 +280,35 @@ void FileSelectDialog::saveSetting()
     drawApp->setDefaultFileDialogNameFilter(DFileDialog::selectedNameFilter());
 }
 
+QString FileSelectDialog::checkAndBuildPath(const QString &path)
+{
+    QFileInfo fileInfo(path);
+    if (!fileInfo.suffix().isEmpty())
+        return path;
+
+    QString suffix = extractSuffix(selectedNameFilter());
+    if (suffix.isEmpty())
+        return path;
+
+    return path + "." + suffix;
+}
+
+QString FileSelectDialog::extractSuffix(const QString &filter)
+{
+    QRegularExpression regex(R"(\(([^)]+)\))");
+    QRegularExpressionMatch match = regex.match(filter);
+    if (!match.hasMatch())
+        return QString();
+
+    QString suffixes = match.captured(1);
+    QStringList suffixList = suffixes.split(' ', Qt::SkipEmptyParts);
+    if (suffixList.isEmpty())
+        return QString();
+
+    QString firstSuffix = suffixList.first().trimmed();
+    if (firstSuffix.startsWith("*.")) {
+        return firstSuffix.mid(2);
+    }
+
+    return QString();
+}

--- a/src/frame/cmultiptabbarwidget.h
+++ b/src/frame/cmultiptabbarwidget.h
@@ -54,6 +54,9 @@ public:
     QString resultFile()const;
 private:
     void saveSetting();
+    QString checkAndBuildPath(const QString &path);
+    QString extractSuffix(const QString &filter);
+
 private:
     QString _resultFile;
 


### PR DESCRIPTION
Implemented checkAndBuildPath and extractSuffix methods to ensure selected file paths are valid and to append the appropriate suffix based on the selected name filter. Updated the file selection logic to utilize these new methods for improved user experience.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-322283.html

## Summary by Sourcery

Ensure valid file paths by automatically appending the appropriate extension based on the selected name filter during file selection.

Bug Fixes:
- Fix failure to save new files without explicit extensions

Enhancements:
- Introduce checkAndBuildPath (using extractSuffix) to validate file paths and append missing extensions