### PR TITLE
fix: Missing rotation

### DIFF
--- a/src/drawshape/drawItems/csizehandlerect.cpp
+++ b/src/drawshape/drawItems/csizehandlerect.cpp
@@ -49,6 +49,8 @@ CSizeHandleRect::CSizeHandleRect(QGraphicsItem *parent, EDirection d, const QStr
     setCacheMode(NoCache);
     //hide();
 
+    m_lightRenderer.load(filename);
+    m_darkRenderer.load(filename);
     setFlag(ItemIsSelectable, false);
     setFlag(ItemIsMovable, false);
 


### PR DESCRIPTION
No resources configured for the renderer, causing the icon to fail to rotate properly.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-326403.html
