### PR TITLE
chore: Update version to 6.5.26

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Draw for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.26) unstable; urgency=medium
+
+  * fix: Missing rotation
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 31 Jul 2025 20:53:57 +0800
+
 deepin-draw (6.5.25) unstable; urgency=medium
 
   * feat: Image format extension support

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Draw for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     Draw for deepin os.


### PR DESCRIPTION
- update version to 6.5.26

log: update version to 6.5.26

## Summary by Sourcery

Bump deepin-draw package version from 6.5.25.1 to 6.5.26.1 across all YAML manifests and update the Debian changelog accordingly.

Chores:
- Update package version to 6.5.26.1 in arm64, amd64, and loong64 linglong.yaml files
- Refresh Debian changelog to reflect the new version