### PR TITLE
fix: Fixed CMYK image display issue

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     Draw for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.30) unstable; urgency=medium
+
+  * fix: Fixed CMYK image display issue Fixed CMYK image display issue
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 15 Aug 2025 11:13:48 +0800
+
 deepin-draw (6.5.29) unstable; urgency=medium
 
   * chore: Update version to 6.5.29

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     Draw for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     Draw for deepin os.

--- a/src/service/filehander.cpp
+++ b/src/service/filehander.cpp
@@ -16,6 +16,7 @@
 #include <QImageReader>
 #include <QPdfWriter>
 #include <QImageWriter>
+#include <QtGlobal>
 
 #if (QT_VERSION_MAJOR == 5)
 #include <QDesktopWidget>
@@ -23,10 +24,101 @@
 #include <QScreen>
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QColorSpace>
+#endif
+
 using Future = QFuture<void>;
 
 #define CURRENTTHREADID \
     reinterpret_cast<long long>(QThread::currentThreadId())
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+/**
+   @brief 转换图片颜色空间到sRGB，解决CMYK等颜色空间图片显示颜色不正确的问题
+   @param image 原始图片
+   @return 转换后的图片，如果不需要转换或转换失败则返回原图
+   @note 此功能仅在Qt6中可用
+ */
+static QImage convertToSRgbColorSpace(const QImage &image)
+{
+    if (image.isNull()) {
+        return image;
+    }
+
+    QColorSpace srgbColorSpace = QColorSpace::SRgb;
+
+    bool needsConversion = false;
+    if (image.colorSpace().isValid()) {
+        qDebug() << "Image has color space:" << image.colorSpace().description();
+
+        if (image.colorSpace() != srgbColorSpace) {
+            needsConversion = true;
+            qDebug() << "Converting color space from" << image.colorSpace().description()
+                                    << "to sRGB";
+        }
+    } else {
+        qDebug() << "Image has no valid color space, checking format for potential CMYK";
+        if (image.format() == QImage::Format_CMYK8888) {
+            needsConversion = true;
+            qDebug() << "CMYK format detected, attempting conversion";
+        }
+    }
+
+    if (!needsConversion) {
+        qDebug() << "No color space conversion needed";
+        return image;
+    }
+
+    QImage convertedImage = QImage();
+
+    try {
+        convertedImage = image.convertedToColorSpace(srgbColorSpace);
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 1 (convertedToColorSpace) succeeded";
+        } else {
+            qDebug() << "Color space conversion method 1 failed";
+        }
+    } catch (...) {
+        qDebug() << "Color space conversion method 1 threw exception";
+    }
+
+    if (convertedImage.isNull()) {
+        qDebug() << "Trying color space conversion method 2: manual color space setting";
+
+        convertedImage = image.copy();
+        convertedImage.setColorSpace(srgbColorSpace);
+
+        if (convertedImage.format() != QImage::Format_RGB888 &&
+            convertedImage.format() != QImage::Format_ARGB32 &&
+            convertedImage.format() != QImage::Format_ARGB32_Premultiplied) {
+            convertedImage = convertedImage.convertToFormat(QImage::Format_RGB888);
+        }
+
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 2 succeeded";
+        }
+    }
+
+    if (convertedImage.isNull()) {
+        qDebug() << "Trying color space conversion method 3: basic format conversion";
+        convertedImage = image.convertToFormat(QImage::Format_RGB888);
+        convertedImage.setColorSpace(srgbColorSpace);
+
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 3 succeeded";
+        }
+    }
+
+    if (convertedImage.isNull()) {
+        qWarning() << "All color space conversion methods failed, returning original image";
+        return image;
+    }
+
+    return convertedImage;
+}
+#endif
+
 class FileHander::FileHander_private
 {
 public:
@@ -650,7 +742,12 @@ QImage FileHander::loadImage(const QString &file)
             qWarning() << "Failed to load image, file may be damaged";
             d_pri()->setError(EDamagedImageFile, tr("Damaged file, unable to open it"));
         }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
+        img = convertToSRgbColorSpace(img);
+#else
         img = img.convertToFormat(QImage::Format_ARGB32);
+#endif
         return img;
     }
     return QImage();


### PR DESCRIPTION
- Fixed CMYK image display issue Fixed CMYK image display issue
- update version to 6.5.30

## Summary by Sourcery

Fix CMYK image display issue by converting loaded images to sRGB under Qt6 and update application version to 6.5.30.1 across packaging

Bug Fixes:
- Convert loaded images to sRGB color space under Qt6 to correct CMYK and other non-sRGB format display issues

Chores:
- Bump application version to 6.5.30.1 in all packaging files