### PR TITLE
fix: save dialog resets filename and format when changing save path

### DIFF
--- a/src/frame/ccentralwidget.cpp
+++ b/src/frame/ccentralwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -160,12 +160,20 @@ public:
     {
         if (toddf) {
             FileSelectDialog dialog(_borad);
+
+            // Set directory first to avoid GTK native dialog resetting
+            // filename and name filter when setDirectory is called later
+            if (!file.isEmpty()) {
+                dialog.setDirectory(QFileInfo(file).dir().absolutePath());
+            } else {
+                dialog.setDirectory(drawApp->defaultFileDialogPath());
+            }
+
             dialog.setNameFilters(drawApp->writableFormatNameFilters());
             dialog.selectNameFilter(drawApp->defaultFileDialogNameFilter());
 
             if (!file.isEmpty()) {
                 dialog.selectFile(file);
-                dialog.setDirectory(QFileInfo(file).dir().absolutePath());
             } else {
                 // Add a format suffix to the default filename
                 QString fullFileName = defaultFileName;
@@ -180,7 +188,6 @@ public:
                     }
                 }
                 dialog.selectFile(fullFileName);
-                dialog.setDirectory(drawApp->defaultFileDialogPath());
             }
             dialog.exec();
 

--- a/src/frame/cmultiptabbarwidget.cpp
+++ b/src/frame/cmultiptabbarwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -193,7 +193,7 @@ FileSelectDialog::FileSelectDialog(DrawBoard *parent): DFileDialog(parent)
     this->setAcceptMode(QFileDialog::AcceptSave);
 
     //只显示文件夹
-    this->setOptions(QFileDialog::DontResolveSymlinks /*| QFileDialog::Option(DontUseNativeDialog)*/);
+    this->setOptions(QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog);
 
     //设置显示模式
     this->setViewMode(DFileDialog::List);


### PR DESCRIPTION
Log: setDirectory() was called after selectFile and selectNameFilter, causing the native GTK dialog to clear the previously set filename and format on directory change. Fixed by moving setDirectory() before filter and file selection so selections persist.

Bug: https://pms.uniontech.com/bug-view-347163.html

## Summary by Sourcery

Bug Fixes:
- Prevent the GTK native save dialog from resetting the selected filename and format when the directory is changed.