### PR TITLE
test: adapt unit tests for Qt5/Qt6 dual compatibility

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 # 定义需要的cmake版本
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
-# 设置cmake参数
-set(CMAKE_CXX_STANDARD 14)
+# 设置cmake参数（与主工程保持一致，使用 C++17）
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -10,6 +10,20 @@ set(CMAKE_AUTOUIC ON)
 
 # 设置工程名字
 project(deepin-draw-test)
+
+# 测试代码需要使用主工程设置的 Qt / DTK 版本
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(Qt6 QUIET)
+    if(Qt6_FOUND)
+        set(QT_VERSION_MAJOR 6)
+        set(DTK_VERSION_MAJOR 6)
+    else()
+        find_package(Qt5 REQUIRED COMPONENTS Core Widgets Gui Test)
+        set(QT_VERSION_MAJOR 5)
+        set(DTK_VERSION_MAJOR "")
+    endif()
+endif()
+message(STATUS "Tests will be built against Qt${QT_VERSION_MAJOR} / DTK${DTK_VERSION_MAJOR}")
 
 option(DEEPINDRAW_TEST_OFFSCREENT "test in off screen." ON)
 if(DEEPINDRAW_TEST_OFFSCREENT)
@@ -105,28 +119,21 @@ if(DEEPINDRAW_TEST_DIALOG_ITEM)
     add_definitions(-DTEST_DIALOG)
 endif()
 
-# 设置Qt模块
-set(QtModule Core Gui Widgets DBus PrintSupport Svg Concurrent LinguistTools Test)
-
-# 查找Qt相关的库链接
-find_package(Qt5 REQUIRED ${QtModule})
+# 设置Qt模块（按 Qt 主版本选择对应组件名）
+if(QT_VERSION_MAJOR EQUAL 6)
+    set(QtModule Core Gui Widgets DBus PrintSupport Svg SvgWidgets Concurrent Test)
+    find_package(Qt6 REQUIRED COMPONENTS ${QtModule})
+else()
+    set(QtModule Core Gui Widgets DBus PrintSupport Svg Concurrent Test)
+    find_package(Qt5 REQUIRED COMPONENTS ${QtModule})
+endif()
 
 #注意mips不支持-fsanitize
 if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "mips64")
-    #set(CMAKE_CXX_FLAGS "-g -O1 -fprofile-arcs -ftest-coverage")
     set(CMAKE_CXX_FLAGS "-g -O1 -fprofile-arcs -ftest-coverage")
-    #set(CMAKE_C_FLAGS "-g -O1 -fprofile-arcs -ftest-coverage")
-    set(CMAKE_Ｌ_FLAGS "-g -O1 -fprofile-arcs -ftest-coverage")
-
-    #mips not support -fsanitize,so only -lgcov when link ${BASE_LIB}.
     set(CMAKE_EXE_LINKER_FLAGS    "-lgcov")
 else()
-   #set(CMAKE_CXX_FLAGS "-fsanitize=undefined,address,leak -fno-omit-frame-pointer -g -O1 -fprofile-arcs -ftest-coverage")
    set(CMAKE_CXX_FLAGS "-g -O1 -fprofile-arcs -ftest-coverage")
-   #set(CMAKE_C_FLAGS "-fsanitize=undefined,address,leak -fno-omit-frame-pointer -g -O1 -fprofile-arcs -ftest-coverage")
-    set(CMAKE_Ｌ_FLAGS "-fsanitize=undefined,address,leak -fno-omit-frame-pointer -g -O1 -fprofile-arcs -ftest-coverage")
-
-    # because ${BASE_LIB} lib is compile with -fsanitize and -lgcov,so we should add those flag when link it.
     set(CMAKE_EXE_LINKER_FLAGS    "-fsanitize=undefined,address,leak -lgcov")
 
     # notice code that we should output memery use info.
@@ -161,9 +168,11 @@ target_link_libraries(${PROJECT_NAME} gmock gmock_main gtest gtest_main pthread 
 # 使用第三方库需要用到的一个包
 find_package(PkgConfig REQUIRED)
 
-# 检查第三方库(这里检查了名字为dtkwidget的库和名字为dtkgui的库)，然后取名3RMODULES
+# 检查第三方库(注意 Qt5 下名为 dtkwidget，Qt6 下名为 dtk6widget)
 pkg_check_modules(3RMODULES REQUIRED
-        dtkwidget dtkgui
+        dtk${DTK_VERSION_MAJOR}widget
+        dtk${DTK_VERSION_MAJOR}gui
+        dtk${DTK_VERSION_MAJOR}core
         )
 
 # 添加第三方库的所有文件夹路径到工程中来(注意 *_INCLUDE_DIRS)
@@ -174,5 +183,7 @@ target_link_libraries(${PROJECT_NAME} ${3RMODULES_LIBRARIES})
 
 #------------------------------添加第三方库end-------------------------------------
 
-# 将工程与Qt模块链接起来
-qt5_use_modules(${PROJECT_NAME} ${QtModule})
+# 将工程与 Qt 模块链接起来（兼容 Qt5 / Qt6）
+foreach(module IN LISTS QtModule)
+    target_link_libraries(${PROJECT_NAME} Qt${QT_VERSION_MAJOR}::${module})
+endforeach()

--- a/tests/testItems/publicApi.cpp
+++ b/tests/testItems/publicApi.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <QtTest>
 #include <QTestEventList>
 #include <qaction.h>
+#include "qteventcompat.h"
 
 
 #include <gtest/gtest.h>
@@ -89,7 +90,7 @@ public:
                 QTest::lastMouseTimestamp += _delay;
             }
 
-            QMouseEvent me(QEvent::MouseMove, _pos, _button, _button, _modifiers);
+            QT_COMPAT_MOUSE_EVENT(me, QEvent::MouseMove, _pos, _button, _button, _modifiers);
             me.setTimestamp(ulong(++QTest::lastMouseTimestamp));
             QSpontaneKeyEvent::setSpontaneous(&me);
             if (!dApp->notify(w, &me)) {
@@ -249,8 +250,8 @@ void setBrushColor(CGraphicsItem *item, QColor color)
 
     item = dynamic_cast<CGraphicsItem *>(item->drawScene()->getBzItems().first());
     //   [0]  show colorPanel
-    QMouseEvent mousePressEvent(QEvent::MouseButtonPress, QPointF(5, 5),
-                                Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QT_COMPAT_MOUSE_EVENT(mousePressEvent, QEvent::MouseButtonPress, QPointF(5, 5),
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     dApp->sendEvent(brush, &mousePressEvent);
     QTest::qWait(200);
     CColorPickWidget *pickColor = brush->colorPick();
@@ -284,11 +285,11 @@ void setBrushColor(CGraphicsItem *item, QColor color)
     QTest::qWait(200);
     dApp->sendEvent(iconbutton, &mousePressEvent);
     QTest::qWait(200);
-    QMouseEvent mouseReleaseEvent(QEvent::MouseButtonRelease, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QT_COMPAT_MOUSE_EVENT(mouseReleaseEvent, QEvent::MouseButtonRelease, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     dApp->sendEvent(iconbutton, &mouseReleaseEvent);
     QTest::qWait(200);
-    event = QEvent(QEvent::Leave);
-    dApp->sendEvent(iconbutton, &event);
+    QEvent leaveEvent(QEvent::Leave);
+    dApp->sendEvent(iconbutton, &leaveEvent);
     QTest::qWait(200);
 
     //  [4]  picker color
@@ -342,30 +343,30 @@ void resizeItem()
     for (int i = 0; i < handles.size(); ++i) {
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
     }
     for (int i = 0; i < handles.size(); ++i) {
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
     }
     for (int i = 0; i < handles.size(); ++i) {
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
     }

--- a/tests/testItems/qteventcompat.h
+++ b/tests/testItems/qteventcompat.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 本头文件提供 Qt5 / Qt6 通用的事件构造辅助宏。
+//
+// 背景：QWheelEvent / QMouseEvent 在 Qt6 中删除了 Qt5 时期的兼容构造函数，
+// 测试代码需要同时兼容两种 Qt 版本，因此在此集中处理差异。
+//
+// 用法：
+//   QT_COMPAT_WHEEL_EVENT(name, pos, delta, button, modifiers)
+//   QT_COMPAT_MOUSE_EVENT(name, type, pos, button, buttons, modifiers)
+// 这两个宏会以正确的参数列表「原地构造」对应类型的局部变量 name。
+
+#ifndef QTEVENTCOMPAT_H
+#define QTEVENTCOMPAT_H
+
+#include <QtGlobal>
+#include <QEvent>
+#include <QPointF>
+#include <QPoint>
+#include <Qt>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  include <QWheelEvent>
+#  include <QMouseEvent>
+#endif
+
+// 构造一个名为 name 的 QWheelEvent 局部变量，参数语义沿用 Qt5 风格：
+//   pos        : 鼠标位置 (QPointF)
+//   delta      : 滚轮增量 (int，正负代表方向)
+//   button     : 触发按键 (Qt::MouseButton)
+//   modifiers  : 修饰键 (Qt::KeyboardModifiers)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  define QT_COMPAT_WHEEL_EVENT(name, pos, delta, button, modifiers)         \
+      QWheelEvent name((pos), (pos), QPoint(), QPoint(0, (delta)),           \
+                       Qt::MouseButtons(button), (modifiers),                \
+                       Qt::NoScrollPhase, false)
+#else
+#  define QT_COMPAT_WHEEL_EVENT(name, pos, delta, button, modifiers)         \
+      QWheelEvent name((pos), (delta), (button), (modifiers))
+#endif
+
+// 构造一个名为 name 的 QMouseEvent 局部变量，参数语义沿用 Qt5 风格：
+//   type       : 事件类型 (QEvent::Type)
+//   pos        : 鼠标位置 (QPointF)
+//   button     : 触发按键 (Qt::MouseButton)
+//   buttons    : 当前按键状态 (Qt::MouseButtons)
+//   modifiers  : 修饰键 (Qt::KeyboardModifiers)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  define QT_COMPAT_MOUSE_EVENT(name, type, pos, button, buttons, modifiers) \
+      QMouseEvent name((type), (pos), (pos), (button), (buttons), (modifiers))
+#else
+#  define QT_COMPAT_MOUSE_EVENT(name, type, pos, button, buttons, modifiers) \
+      QMouseEvent name((type), (pos), (button), (buttons), (modifiers))
+#endif
+
+#endif // QTEVENTCOMPAT_H

--- a/tests/testItems/test_ellipseItem.cpp
+++ b/tests/testItems/test_ellipseItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 #include "cdrawtoolfactory.h"
 #undef protected
 #undef private
+#include "qteventcompat.h"
 
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
@@ -164,11 +165,11 @@ TEST(EllipseItem, TestSelectAllEllipseItem)
     emit view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_function.cpp
+++ b/tests/testItems/test_function.cpp
@@ -1,6 +1,11 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "qteventcompat.h"
+// Pre-include standard headers before #define private public to avoid
+// breaking C++ standard library internals (e.g. std::basic_stringbuf).
+#include <sstream>
 
 #define protected public
 #define private public
@@ -303,7 +308,7 @@ TEST(TestFunction, CSpinBox)
 
     box.contextMenuEvent(nullptr);
 
-    QMouseEvent e_md(QEvent::Type::MouseButtonDblClick, QPointF(1, 1), Qt::MouseButton::LeftButton, Qt::MouseButtons(), Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_MOUSE_EVENT(e_md, QEvent::Type::MouseButtonDblClick, QPointF(1, 1), Qt::MouseButton::LeftButton, Qt::MouseButtons(), Qt::KeyboardModifier::NoModifier);
     box.mouseDoubleClickEvent(&e_md);
 }
 
@@ -410,7 +415,7 @@ TEST(TestFunction, CDrawToolEvent)
     auto scene = page->scene();
 
     //mouse
-    QMouseEvent e_1(QEvent::Type::MouseButtonPress, QPointF(100, 100), Qt::MouseButton::LeftButton, Qt::MouseButtons(), Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_MOUSE_EVENT(e_1, QEvent::Type::MouseButtonPress, QPointF(100, 100), Qt::MouseButton::LeftButton, Qt::MouseButtons(), Qt::KeyboardModifier::NoModifier);
     CDrawToolEvent::fromQEvent(&e_1, scene);
 
     //touch

--- a/tests/testItems/test_lineItem.cpp
+++ b/tests/testItems/test_lineItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,7 @@
 #include "cviewmanagement.h"
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -219,11 +220,11 @@ TEST(LineItem, TestSelectAllLineItem)
     emit view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_pictureItem.cpp
+++ b/tests/testItems/test_pictureItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,8 @@
 #define private public
 #include "cgraphicsview.h"
 #include <qaction.h>
+
+#include "qteventcompat.h"
 
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
@@ -322,11 +324,11 @@ TEST(PictureItem, TestSelectAllPictureItem)
     view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_polygonItem.cpp
+++ b/tests/testItems/test_polygonItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <qaction.h>
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -186,11 +187,11 @@ TEST(PolygonItem, TestSelectAllPolygonItem)
     emit view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_rectItem.cpp
+++ b/tests/testItems/test_rectItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <qaction.h>
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -174,11 +175,11 @@ TEST(RectItem, TestSelectAllRectItem)
     view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 200, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_startItem.cpp
+++ b/tests/testItems/test_startItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <qaction.h>
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -223,11 +224,11 @@ TEST(StartItem, TestSelectAllStartItem)
     view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_textItem.cpp
+++ b/tests/testItems/test_textItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <qaction.h>
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -307,45 +308,45 @@ TEST(TextItem, TestTextItemProperty)
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
 
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent2(QEvent::MouseButtonRelease, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent2, QEvent::MouseButtonRelease, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent2);
         QTest::qWait(delay);
     }
     for (int i = 0; i < handles.size(); ++i) {
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent2(QEvent::MouseButtonRelease, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent2, QEvent::MouseButtonRelease, posInView - QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent2);
         QTest::qWait(delay);
     }
     for (int i = 0; i < handles.size(); ++i) {
         CSizeHandleRect *pNode = handles[i];
         QPoint posInView = view->mapFromScene(pNode->mapToScene(pNode->boundingRect().center()));
-        QMouseEvent mouseEvent(QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent, QEvent::MouseButtonPress, posInView, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent1(QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent1, QEvent::MouseMove, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent1);
         QTest::qWait(delay);
 
-        QMouseEvent mouseEvent2(QEvent::MouseButtonRelease, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
+        QT_COMPAT_MOUSE_EVENT(mouseEvent2, QEvent::MouseButtonRelease, posInView + QPoint(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier | Qt::AltModifier);
         QApplication::sendEvent(view->viewport(), &mouseEvent2);
         QTest::qWait(delay);
     }
@@ -390,11 +391,11 @@ TEST(TextItem, TestSelectAllTextItem)
 
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/testItems/test_triangleItem.cpp
+++ b/tests/testItems/test_triangleItem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <qaction.h>
 #undef protected
 #undef private
+#include "qteventcompat.h"
 #include "ccentralwidget.h"
 #include "clefttoolbar.h"
 #include "toptoolbar.h"
@@ -161,11 +162,11 @@ TEST(TriangleItem, TestSelectAllTriangleItem)
     view->m_itemsHEqulSpaceAlign->triggered(true);
 
     //滚轮事件
-    QWheelEvent wheelevent(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ControlModifier);
     view->wheelEvent(&wheelevent);
-    QWheelEvent wheelevent2(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent2, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier);
     view->wheelEvent(&wheelevent2);
-    QWheelEvent wheelevent3(QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
+    QT_COMPAT_WHEEL_EVENT(wheelevent3, QPointF(1000, 1000), 100, Qt::MouseButton::NoButton, Qt::KeyboardModifier::ShiftModifier);
     view->wheelEvent(&wheelevent3);
 }
 

--- a/tests/test_qtestmain.cpp
+++ b/tests/test_qtestmain.cpp
@@ -1,6 +1,10 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
+
+// Pre-include standard headers before #define private to avoid
+// breaking C++ standard library internals (e.g. std::basic_stringbuf).
+#include <sstream>
 
 #define private protected
 #include <QtTest>
@@ -48,7 +52,6 @@ static void initQrcIfStaticLib()
 
 #define QMYTEST_MAIN(TestObject) \
     QT_BEGIN_NAMESPACE \
-    QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS \
     QT_END_NAMESPACE \
     int main(int argc, char *argv[]) \
     { \
@@ -56,7 +59,6 @@ static void initQrcIfStaticLib()
         initQrcIfStaticLib();\
         Application app(argc, argv); \
         QTEST_DISABLE_KEYPAD_NAVIGATION \
-        QTEST_ADD_GPU_BLACKLIST_SUPPORT \
         TestObject tc; \
         QTEST_SET_MAIN_SOURCE_PATH \
         return QTest::qExec(&tc, argc, argv); \


### PR DESCRIPTION
Add qteventcompat.h with QT_COMPAT_MOUSE_EVENT and QT_COMPAT_WHEEL_EVENT macros to handle QMouseEvent and QWheelEvent constructor signature changes between Qt5/Qt6.

Update CMakeLists.txt to auto-detect Qt version (5 or 6), upgrade C++ standard to C++17, use modern cmake target-based linking, and remove deprecated qt5_use_modules.

添加qteventcompat.h兼容头文件，处理Qt5/Qt6鼠标和滚轮
事件构造函数签名差异；更新CMake构建系统自动检测Qt版本，
升级C++标准至C++17，使用现代CMake链接方式。

Log: 单元测试适配Qt5/Qt6双版本兼容
Influence: 测试代码可同时兼容Qt5和Qt6构建环境，无需
手动修改事件构造代码即可在不同Qt版本上编译运行。