### PR TITLE
fix: update save state

### DIFF
--- a/src/drawshape/cdrawparamsigleton.cpp
+++ b/src/drawshape/cdrawparamsigleton.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -258,11 +258,9 @@ bool PageContext::save(const QString &file)
         QFileInfo info(filePath);
         if ("ddf" == info.suffix().toLower()) {
             qDebug() << "Saving as DDF file";
-            _dirty = 0;
             rs = page()->borad()->fileHander()->saveToDdf(this, filePath);
         } else {
             qDebug() << "Saving as image file";
-            _dirty = 0;
             rs = page()->borad()->fileHander()->saveToImage(this, filePath);
             //保存成功
             if (rs) {

--- a/src/frame/ccentralwidget.cpp
+++ b/src/frame/ccentralwidget.cpp
@@ -560,6 +560,8 @@ bool Page::save(const QString &file)
                         result = save(anotherFile);
                 }
             }
+        } else {
+            borad()->setPageTitle(this, this->title());
         }
 
         return result;
@@ -1187,7 +1189,6 @@ void DrawBoard::loadFiles(QStringList filePaths, bool bInThread,  int loadTypeFo
                         addPage("");
                         currentPage()->setPageRect(QRectF(QPointF(0, 0), img.size()));
                         currentPage()->setFile(path);
-                        currentPage()->context()->setDirty(false);
                         bNewPage = true;
                     }
 
@@ -1213,6 +1214,9 @@ void DrawBoard::loadFiles(QStringList filePaths, bool bInThread,  int loadTypeFo
                             currentPage()->context()->addImage(img, pos, rect, !bNewPage, true);
                         }
                     }
+
+                    if (bNewPage)
+                        currentPage()->context()->setDirty(false);
                 }, connectType);
             }
         }


### PR DESCRIPTION
log: Remove premature _dirty=0 assignments before save calls so that setDirty(false) can properly emit dirtyChanged after a successful save, allowing the tab title * prefix to be cleared.

pms: bug-364361