### PR TITLE
fix: update version to 6.5.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-draw (6.5.41) unstable; urgency=medium
+
+  * update version to 6.5.41
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Fri, 05 Jun 2026 13:54:58 +0800
+
 deepin-draw (6.5.40) unstable; urgency=medium
 
   * chore: Update version to 6.5.40

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.draw
   name: deepin-draw
-  version: 6.5.40.1
+  version: 6.5.41.1
   kind: app
   description: |
     Draw for deepin os.


### PR DESCRIPTION
log: update version.

## Summary by Sourcery

Build:
- Bump package version in linglong.yaml from 6.5.40.1 to 6.5.41.1.