### PR TITLE
fix(shutdown): use delay inhibitor for unsaved drawings

### DIFF
--- a/src/frame/mainwindow.cpp
+++ b/src/frame/mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -57,7 +57,7 @@ static void notifySystemBlocked(bool block)
         m_arg << QString("shutdown")                // what
               << qApp->productName()                // who
               << QObject::tr("File not saved")      // why
-              << QString("block");                  // mode
+              << QString("delay");                  // mode
 
         m_reply = m_pLoginManager->callWithArgumentList(QDBus::Block, "Inhibit", m_arg);
 
@@ -68,7 +68,7 @@ static void notifySystemBlocked(bool block)
         QDBusReply<QDBusUnixFileDescriptor> tmp = m_reply;
         m_reply = QDBusReply<QDBusUnixFileDescriptor>();
     } else {
-        m_reply = m_pLoginManager->callWithArgumentList(QDBus::Block, "Inhibit", m_arg);//阻止关机
+        m_reply = m_pLoginManager->callWithArgumentList(QDBus::Block, "Inhibit", m_arg); // 延迟关机，允许强制操作
     }
 }
 


### PR DESCRIPTION
Use a delay inhibitor so the session can offer force shutdown.

未保存画板内容时使用延迟抑制器，使会话可提供强制关机操作。

Log: 修复未保存画板内容时无法强制关机的问题
Bug: https://pms.uniontech.com/bug-view-370331.html
Influence: 关机流程将展示会话层的强制关机操作，不影响保存提示。

## Summary by Sourcery

Bug Fixes:
- Allow force shutdown to proceed even when drawings are unsaved by switching to a delay inhibitor instead of a full block.