### PR TITLE
fix: restore file manager dialog in save-as instead of Qt native dialog

### DIFF
--- a/src/frame/cmultiptabbarwidget.cpp
+++ b/src/frame/cmultiptabbarwidget.cpp
@@ -193,7 +193,7 @@ FileSelectDialog::FileSelectDialog(DrawBoard *parent): DFileDialog(parent)
     this->setAcceptMode(QFileDialog::AcceptSave);
 
     //只显示文件夹
-    this->setOptions(QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog);
+    this->setOptions(QFileDialog::DontResolveSymlinks /*| QFileDialog::Option(DontUseNativeDialog)*/);
 
     //设置显示模式
     this->setViewMode(DFileDialog::List);


### PR DESCRIPTION
Log: remove DontUseNativeDialog flag added by 52d61669, the setDirectory reordering fix in ccentralwidget.cpp is sufficient to prevent filename and format reset; the DontUseNativeDialog flag caused the save-as dialog to use Qt's built-in dialog instead of the DTK file manager dialog.

Pms: bug-371081