### PR TITLE
fix: upgrade actions/checkout to v7 and allow unsafe pr checkout

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Log: fix CI failure caused by actions/checkout@v2 refusing to check out fork PR code in pull_request_target workflow

Pms: