### PR TITLE
fix(print): render page with white background

### DIFF
--- a/src/frame/toptoolbar.cpp
+++ b/src/frame/toptoolbar.cpp
@@ -202,8 +202,8 @@ void TopTilte::initMenu()
             CPrintManager manager(drawApp->topMainWindowWidget());
             auto page = drawApp->drawBoard()->currentPage();
             if (page != nullptr && page->context() != nullptr)
-                manager.showPrintDialog(page->context()->renderToImage(), drawApp->topMainWindowWidget(),
-                                        page->name());
+                manager.showPrintDialog(page->context()->renderToImage(Qt::white), drawApp->topMainWindowWidget(),
+                                         page->name());
         });
     } else {
         QAction *exportAc = new QAction(tr("Export"), this);


### PR DESCRIPTION
在打印时调用 renderToImage（Qt：:white），确保打印页面使用不透明白色背景。

Log：修复打印预览页面背景透明的问题，泣染页面图像时指定 Qt：:white 作为背景色。
Bug: https://pms.uniontech.com/bug-view-221301.html
