### PR TITLE
fix(attributes): use palette text color

### DIFF
--- a/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+++ b/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
@@ -197,7 +197,7 @@ void DrawAttribution::CColorSettingButton::paintFillArea(QPainter *painter)
 
     //绘制常量文字("填充")
     painter->save();
-    painter->setPen(darkTheme ? QColor("#C0C6D4") : QColor("#414D68"));
+    painter->setPen(palette().color(QPalette::WindowText));
     painter->drawText(textRct, _text, QTextOption(Qt::AlignLeft | Qt::AlignVCenter));
     painter->restore();
 }
@@ -258,7 +258,7 @@ void DrawAttribution::CColorSettingButton::paintFillBorder(QPainter *painter)
 
     //绘制常量文字("描边")
     painter->save();
-    painter->setPen(darkTheme ? QColor("#C0C6D4") : QColor("#414D68"));
+    painter->setPen(palette().color(QPalette::WindowText));
     painter->drawText(textRct, _text, QTextOption(Qt::AlignLeft | Qt::AlignVCenter));
     painter->restore();
 }

--- a/src/frame/toptoolbar.cpp
+++ b/src/frame/toptoolbar.cpp
@@ -202,8 +202,8 @@ void TopTilte::initMenu()
             CPrintManager manager(drawApp->topMainWindowWidget());
             auto page = drawApp->drawBoard()->currentPage();
             if (page != nullptr && page->context() != nullptr)
-                manager.showPrintDialog(page->context()->renderToImage(), drawApp->topMainWindowWidget(),
-                                        page->name());
+                manager.showPrintDialog(page->context()->renderToImage(Qt::white), drawApp->topMainWindowWidget(),
+                                         page->name());
         });
     } else {
         QAction *exportAc = new QAction(tr("Export"), this);


### PR DESCRIPTION
## 问题\n修复右侧工具属性栏中颜色属性标签与圆角控件文字颜色不一致的问题。\n\n## 修复方案\n颜色属性标签绘制时使用当前调色板的 `QPalette::WindowText`，替代硬编码的深浅主题色值，使其与 DTK 控件保持一致并随主题自动适配。\n\n## 验证\n- `cmake --build obj-x86_64-linux-gnu -j2`\n\n## PMS\n- BUG-231619\n- 根因分析：[analysis-report.md](.pms/bugs/231619/analysis-report.md)

## Summary by Sourcery

Align attribute color label text with the active theme palette and adjust print dialog rendering to use a white background image.

Bug Fixes:
- Use the current palette's window text color for color attribute labels to keep them consistent with themed controls.
- Render the page image with an explicit white background when opening the print dialog to avoid incorrect background colors.