### PR TITLE
fix(attributes): use palette text color

### DIFF
--- a/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+++ b/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
@@ -197,7 +197,7 @@ void DrawAttribution::CColorSettingButton::paintFillArea(QPainter *painter)
 
     //绘制常量文字("填充")
     painter->save();
-    painter->setPen(darkTheme ? QColor("#C0C6D4") : QColor("#414D68"));
+    painter->setPen(palette().color(QPalette::WindowText));
     painter->drawText(textRct, _text, QTextOption(Qt::AlignLeft | Qt::AlignVCenter));
     painter->restore();
 }
@@ -258,7 +258,7 @@ void DrawAttribution::CColorSettingButton::paintFillBorder(QPainter *painter)
 
     //绘制常量文字("描边")
     painter->save();
-    painter->setPen(darkTheme ? QColor("#C0C6D4") : QColor("#414D68"));
+    painter->setPen(palette().color(QPalette::WindowText));
     painter->drawText(textRct, _text, QTextOption(Qt::AlignLeft | Qt::AlignVCenter));
     painter->restore();
 }


### PR DESCRIPTION
## 问题\n修复右侧工具属性栏中颜色属性标签与圆角控件文字颜色不一致的问题。\n\n## 修复方案\n颜色属性标签绘制时使用当前调色板的 `QPalette::WindowText`，替代硬编码的深浅主题色值，使其与 DTK 控件保持一致并随主题自动适配。\n\n## 验证\n- `cmake --build obj-x86_64-linux-gnu -j2`\n\n## PMS\n- BUG-231619\n- 根因分析：[analysis-report.md](.pms/bugs/231619/analysis-report.md)

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent text color for color attribute labels and rounded corner controls in the attributes sidebar by using the active palette window text color.