### PR TITLE
fix(print): render page with white background

### DIFF
--- a/src/frame/toptoolbar.cpp
+++ b/src/frame/toptoolbar.cpp
@@ -202,8 +202,8 @@ void TopTilte::initMenu()
             CPrintManager manager(drawApp->topMainWindowWidget());
             auto page = drawApp->drawBoard()->currentPage();
             if (page != nullptr && page->context() != nullptr)
-                manager.showPrintDialog(page->context()->renderToImage(), drawApp->topMainWindowWidget(),
-                                        page->name());
+                manager.showPrintDialog(page->context()->renderToImage(Qt::white), drawApp->topMainWindowWidget(),
+                                         page->name());
         });
     } else {
         QAction *exportAc = new QAction(tr("Export"), this);


### PR DESCRIPTION
## 问题\n修复打印预览中透明画布区域显示黑色矩形框的问题。\n\n## 修复方案\n在打印入口渲染页面图像时显式传入 `Qt::white` 作为背景色，避免透明像素在预览或打印后端按黑色合成。\n\n## 验证\n- `cmake --build obj-x86_64-linux-gnu -j2`\n\n## PMS\n- BUG-221301\n- 根因分析：[analysis-report.md](.pms/bugs/221301/analysis-report.md)

## Summary by Sourcery

Bug Fixes:
- Fix print preview and backend rendering where transparent canvas regions appeared as black rectangles by rendering page images with an explicit white background.