### PR TITLE
fix(color): adapt color controls to compact mode

### DIFF
--- a/src/frame/AttributesWidgets/private/colorpanel.cpp
+++ b/src/frame/AttributesWidgets/private/colorpanel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,6 +37,10 @@ const int ORIGIN_HEIGHT = 250;
 const int EXPAND_HEIGHT = 475;
 const int RADIUS = 8;
 const QSize COLOR_BORDER_SIZE = QSize(34, 34);
+const QSize COLORFUL_BUTTON_SIZE_NORMAL = QSize(55, 36);
+const QSize COLORFUL_BUTTON_SIZE_COMPACT = QSize(55, 24);
+const QSize COLOR_LINE_EDIT_SIZE_NORMAL = QSize(180, 36);
+const QSize COLOR_LINE_EDIT_SIZE_COMPACT = QSize(180, 24);
 
 bool ColorPanel::s_expand = false;
 ColorButton::ColorButton(const QColor &color, DWidget *parent)
@@ -161,7 +165,7 @@ void ColorPanel::initUI()
 
     m_colLineEdit = new DLineEdit(colorValueWidget);
     m_colLineEdit->setObjectName("ColorLineEdit");
-    m_colLineEdit->setFixedSize(180, 36);
+    m_colLineEdit->setFixedSize(COLOR_LINE_EDIT_SIZE_NORMAL);
     m_colLineEdit->setClearButtonEnabled(false);
     m_colLineEdit->lineEdit()->setValidator(new QRegExpValidator(QRegExp("[0-9A-Fa-f]{6}"), this));
     m_colLineEdit->setText("ffffff");
@@ -181,9 +185,15 @@ void ColorPanel::initUI()
     pictureMap[DGuiApplicationHelper::DarkType][CIconButton::Press] = QString(":/theme/dark/images/draw/palette_normal.svg");
     pictureMap[DGuiApplicationHelper::DarkType][CIconButton::Active] = QString(":/theme/dark/images/draw/palette_normal.svg");
 
-    m_colorfulBtn = new CIconButton(pictureMap, QSize(55, 36), colorValueWidget, false);
+    m_colorfulBtn = new CIconButton(pictureMap, COLORFUL_BUTTON_SIZE_NORMAL, colorValueWidget, false);
     m_colorfulBtn->setObjectName("CIconButton");
     m_colorfulBtn->setFocusPolicy(Qt::NoFocus);
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    updateColorfulButtonSize(DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::CompactMode);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this](DGuiApplicationHelper::SizeMode sizeMode) {
+        updateColorfulButtonSize(sizeMode == DGuiApplicationHelper::CompactMode);
+    });
+#endif
 
     QHBoxLayout *colorLayout = new QHBoxLayout(colorValueWidget);
     colorLayout->setMargin(0);
@@ -352,6 +362,14 @@ void ColorPanel::updateColor(const QColor &previewColor)
     m_colLineEdit->blockSignals(true);
     m_colLineEdit->setText(colorName);
     m_colLineEdit->blockSignals(false);
+}
+
+void ColorPanel::updateColorfulButtonSize(bool compact)
+{
+    const QSize buttonSize = compact ? COLORFUL_BUTTON_SIZE_COMPACT : COLORFUL_BUTTON_SIZE_NORMAL;
+    m_colLineEdit->setFixedSize(compact ? COLOR_LINE_EDIT_SIZE_COMPACT : COLOR_LINE_EDIT_SIZE_NORMAL);
+    m_colorfulBtn->setFixedSize(buttonSize);
+    m_colorfulBtn->setIconSize(buttonSize);
 }
 
 void ColorPanel::updateExpendArea()

--- a/src/frame/AttributesWidgets/private/colorpanel.h
+++ b/src/frame/AttributesWidgets/private/colorpanel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -103,6 +103,7 @@ private:
      * @brief updateExpendArea 刷新扩展区域
      */
     void updateExpendArea();
+    void updateColorfulButtonSize(bool compact);
 
 private:
     /* pick widget 十六进制颜色编辑 */

--- a/src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+++ b/src/frame/AttributesWidgets/private/pickcolorwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,10 @@
 DGUI_USE_NAMESPACE
 
 const QSize PICKCOLOR_WIDGET_SIZE = QSize(294, 215);
+const QSize RGB_CONTROL_SIZE_NORMAL = QSize(55, 36);
+const QSize RGB_CONTROL_SIZE_COMPACT = QSize(55, 24);
+const QSize PICKER_ICON_SIZE_NORMAL = QSize(36, 36);
+const QSize PICKER_ICON_SIZE_COMPACT = QSize(24, 24);
 
 PickColorWidget::PickColorWidget(DWidget *parent)
     : DWidget(parent)
@@ -56,10 +60,16 @@ PickColorWidget::PickColorWidget(DWidget *parent)
     QMap<int, QMap<CIconButton::EIconButtonSattus, QString>> pictureMap;
 
     //取色器使用系统托管icon方式设置图标
-    m_picker = new CIconButton(pictureMap, QSize(55, 36), this, false);
+    m_picker = new CIconButton(pictureMap, RGB_CONTROL_SIZE_NORMAL, this, false);
     m_picker->setIconMode();
-    m_picker->setIconSize(QSize(36, 36));
+    m_picker->setIconSize(PICKER_ICON_SIZE_NORMAL);
     m_picker->setIcon(QIcon::fromTheme("dorpper_normal"));
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    updateRgbControlSize(DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::CompactMode);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this](DGuiApplicationHelper::SizeMode sizeMode) {
+        updateRgbControlSize(sizeMode == DGuiApplicationHelper::CompactMode);
+    });
+#endif
 
     QHBoxLayout *rgbLayout = new QHBoxLayout;
     rgbLayout->setMargin(0);
@@ -101,6 +111,16 @@ PickColorWidget::PickColorWidget(DWidget *parent)
     mLayout->addSpacing(11);
     mLayout->addWidget(m_colorSlider, 0, Qt::AlignCenter);
     setLayout(mLayout);
+}
+
+void PickColorWidget::updateRgbControlSize(bool compact)
+{
+    const QSize controlSize = compact ? RGB_CONTROL_SIZE_COMPACT : RGB_CONTROL_SIZE_NORMAL;
+    m_redEditLabel->setFixedSize(controlSize);
+    m_greenEditLabel->setFixedSize(controlSize);
+    m_blueEditLabel->setFixedSize(controlSize);
+    m_picker->setFixedSize(controlSize);
+    m_picker->setIconSize(compact ? PICKER_ICON_SIZE_COMPACT : PICKER_ICON_SIZE_NORMAL);
 }
 
 void PickColorWidget::updateColor(const QColor &color)

--- a/src/frame/AttributesWidgets/private/pickcolorwidget.h
+++ b/src/frame/AttributesWidgets/private/pickcolorwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -59,6 +59,7 @@ private:
      * @brief updateColor　更新颜色
      */
     void updateColor(const QColor &color = QColor());
+    void updateRgbControlSize(bool compact);
 
 private:
     EditLabel *m_redEditLabel;


### PR DESCRIPTION
## Summary

- adapt the palette button height to DTK compact mode
- keep RGB inputs and the color picker button at the same height
- update control sizes when the application size mode changes

## Verification

- `cmake --build build --parallel 4`
- `git diff --check`

PMS: BUG-231613