### PR TITLE
fix: add AT-SPI accessible names for UI widgets

### DIFF
--- a/src/drawshape/drawItems/bzItems/cgraphicstextitem.cpp
+++ b/src/drawshape/drawItems/bzItems/cgraphicstextitem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -92,6 +92,7 @@ void CGraphicsTextItem::initTextEditor(const QString &text)
 {
     qDebug() << "Initializing text editor with text:" << text;
     m_pTextEdit = new CTextEdit(this);
+    m_pTextEdit->setAccessibleName("TextEditor");
     m_pTextEdit->setText(text);
     m_pTextEdit->setMinimumSize(QSize(1, 1));
 

--- a/src/frame/AttributesWidgets/private/blurwidget.cpp
+++ b/src/frame/AttributesWidgets/private/blurwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -81,6 +81,7 @@ SBLurEffect BlurWidget::getEffect() const
 void BlurWidget::initUI()
 {
     this->setObjectName("BlurWidget");
+    this->setAccessibleName("BlurWidget");
     setAttribute(Qt::WA_NoMousePropagation, true);
     DLabel *penLabel = new DLabel(this);
     penLabel->setObjectName("TypeLabel");
@@ -114,6 +115,7 @@ void BlurWidget::initUI()
     m_masicBtn->setIcon(QIcon::fromTheme("ddc_smudge tool"));
 
     m_TypeButtons = new QButtonGroup(this);
+    m_TypeButtons->setObjectName("BlurTypeGroup");
     m_TypeButtons->addButton(m_blurBtn, BlurEffect);
     m_TypeButtons->addButton(m_masicBtn, MasicoEffect);
     m_TypeButtons->setExclusive(true);
@@ -131,10 +133,12 @@ void BlurWidget::initUI()
 
     DLabel *penWidthLabel = new DLabel(this);
     penWidthLabel->setObjectName("Width");
+    penWidthLabel->setAccessibleName("Width");
     penWidthLabel->setText(tr("Width"));
 
     m_spinboxForLineWidth = new CSpinBox(this);
     m_spinboxForLineWidth->setObjectName("BlurPenWidth");
+    m_spinboxForLineWidth->setAccessibleName("BlurPenWidth");
     m_spinboxForLineWidth->setKeyboardTracking(false);
 
     m_spinboxForLineWidth->setSpinRange(5, 500);
@@ -155,6 +159,7 @@ void BlurWidget::initUI()
 
     m_pLineWidthLabel = new DLabel(this);
     m_pLineWidthLabel->setObjectName("Width Label");
+    m_pLineWidthLabel->setAccessibleName("WidthLabel");
     m_pLineWidthLabel->setText(QString("%1px").arg(m_spinboxForLineWidth->value()));
     m_pLineWidthLabel->setFixedWidth(60);
     m_pLineWidthLabel->hide();

--- a/src/frame/AttributesWidgets/private/calphacontrolwidget.cpp
+++ b/src/frame/AttributesWidgets/private/calphacontrolwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -54,6 +54,8 @@ void CAlphaControlWidget::initUI()
     nameLabel->setFont(nameLabelFont);
 
     m_alphaLabel = new DLineEdit(this);
+    m_alphaLabel->setObjectName("AlphaLabel");
+    m_alphaLabel->setAccessibleName("AlphaLabel");
     m_alphaLabel->setFixedSize(QSize(65, 36));
     m_alphaLabel->setClearButtonEnabled(false);
     m_alphaLabel->lineEdit()->setReadOnly(true);

--- a/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+++ b/src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -282,6 +282,8 @@ CComBoxSettingWgt::CComBoxSettingWgt(const QString &text, QWidget *parent):
     CAttributeWgt(-1, parent)
 {
     _comBox = new QComboBox(this);
+    _comBox->setObjectName("AttrComboBox");
+    _comBox->setAccessibleName("AttrComboBox");
     _comBox->setMaximumHeight(36);
     _comBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     _lab    = new QLabel(this);
@@ -376,6 +378,8 @@ CSpinBoxSettingWgt::CSpinBoxSettingWgt(const QString &text, QWidget *parent):
     CAttributeWgt(-1, parent)
 {
     _spinBox = new CSpinBox(this);
+    _spinBox->setObjectName("AttrSpinBox");
+    _spinBox->setAccessibleName("AttrSpinBox");
     _spinBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     _lab    = new QLabel(this);
     _lab->setText(text);
@@ -511,6 +515,7 @@ CGroupButtonWgt::CGroupButtonWgt(QWidget *parent): CAttributeWgt(EGroupWgt, pare
     {
         //组合按钮
         expGroupBtn = new ToolButton(this);
+        expGroupBtn->setAccessibleName("AttrGroupButton");
         //expGroupBtn->setFixedSize(200, 34);
         expGroupBtn->setMinimumSize(200, 34);
         expGroupBtn->setText(tr("Group"));
@@ -519,6 +524,7 @@ CGroupButtonWgt::CGroupButtonWgt(QWidget *parent): CAttributeWgt(EGroupWgt, pare
 
         //释放组合按钮
         expUnGroupBtn = new ToolButton(this);
+        expUnGroupBtn->setAccessibleName("AttrUngroupButton");
         //expUnGroupBtn->setFixedSize(200, 34);
         expUnGroupBtn->setMinimumSize(200, 34);
         expUnGroupBtn->setText(tr("Ungroup"));
@@ -752,6 +758,7 @@ CExpButton *CAttriBaseOverallWgt::getExpButton()
 {
     if (_expBtn == nullptr) {
         _expBtn = new CExpButton(this);
+        _expBtn->setAccessibleName("AttrExpandButton");
     }
     return _expBtn;
 }

--- a/src/frame/AttributesWidgets/private/cattributemanagerwgt.cpp
+++ b/src/frame/AttributesWidgets/private/cattributemanagerwgt.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,7 @@
 CExpButton::CExpButton(QWidget *parent): QWidget(parent)
 {
     _expBtn  = new DIconButton(this);
+    _expBtn->setAccessibleName("ExpandButton");
     _expBtn->setIcon(QIcon::fromTheme("icon_open_normal"));
     _expBtn->setFixedSize(36, 36);
     _expBtn->setIconSize(QSize(30, 30));

--- a/src/frame/AttributesWidgets/private/ccutwidget.cpp
+++ b/src/frame/AttributesWidgets/private/ccutwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -253,6 +253,7 @@ void CCutWidget::initUI()
 
     m_widthEdit = new DLineEdit(m_sizeWidget);
     m_widthEdit->setObjectName("CutWidthLineEdit");
+    m_widthEdit->setAccessibleName("CutWidthLineEdit");
     m_widthEdit->setText(QString::number(800));
     m_widthEdit->setClearButtonEnabled(false);
     m_widthEdit->setFixedWidth(withNotVarble ? 47 : 60);
@@ -265,6 +266,7 @@ void CCutWidget::initUI()
 
     m_heightEdit = new DLineEdit(m_sizeWidget);
     m_heightEdit->setObjectName("CutHeightLineEdit");
+    m_heightEdit->setAccessibleName("CutHeightLineEdit");
     m_heightEdit->setText(QString::number(600));
     m_heightEdit->setClearButtonEnabled(false);
     m_heightEdit->setFixedWidth(withNotVarble ? 47 : 60);

--- a/src/frame/AttributesWidgets/private/colorpanel.cpp
+++ b/src/frame/AttributesWidgets/private/colorpanel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -134,6 +134,7 @@ void ColorPanel::initUI()
     m_colList = specifiedColorList();
 
     m_colorsButtonGroup = new QButtonGroup(this);
+    m_colorsButtonGroup->setObjectName("ColorsButtonGroup");
     m_colorsButtonGroup->setExclusive(true);
 
     QGridLayout *gLayout = new QGridLayout;
@@ -151,6 +152,7 @@ void ColorPanel::initUI()
 
     m_alphaControlWidget = new CAlphaControlWidget(this);
     m_alphaControlWidget->setObjectName("CAlphaControlWidget");
+    m_alphaControlWidget->setAccessibleName("CAlphaControlWidget");
     m_alphaControlWidget->setFocusPolicy(Qt::NoFocus);
 
     DWidget *colorValueWidget = new DWidget(this);
@@ -165,6 +167,7 @@ void ColorPanel::initUI()
 
     m_colLineEdit = new DLineEdit(colorValueWidget);
     m_colLineEdit->setObjectName("ColorLineEdit");
+    m_colLineEdit->setAccessibleName("ColorLineEdit");
     m_colLineEdit->setFixedSize(180, 36);
     m_colLineEdit->setClearButtonEnabled(false);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -191,6 +194,7 @@ void ColorPanel::initUI()
 
     m_colorfulBtn = new CIconButton(pictureMap, QSize(55, 36), colorValueWidget, false);
     m_colorfulBtn->setObjectName("CIconButton");
+    m_colorfulBtn->setAccessibleName("ColorfulBtn");
     m_colorfulBtn->setFocusPolicy(Qt::NoFocus);
 
     QHBoxLayout *colorLayout = new QHBoxLayout(colorValueWidget);
@@ -204,6 +208,7 @@ void ColorPanel::initUI()
 
     m_pickColWidget = new PickColorWidget(this);
     m_pickColWidget->setObjectName("PickColorWidget");
+    m_pickColWidget->setAccessibleName("PickColorWidget");
     m_pickColWidget->setFocusPolicy(Qt::NoFocus);
 
     QVBoxLayout *vLayout = new QVBoxLayout(colorBtnWidget);

--- a/src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+++ b/src/frame/AttributesWidgets/private/pickcolorwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,7 @@ const QSize PICKCOLOR_WIDGET_SIZE = QSize(294, 215);
 PickColorWidget::PickColorWidget(DWidget *parent)
     : DWidget(parent)
 {
+    this->setAccessibleName("PickColorWidget");
     setFixedSize(PICKCOLOR_WIDGET_SIZE);
     DLabel *titleLabel = new DLabel(this);
     QFont titleLabelFont = titleLabel->font();
@@ -49,15 +50,23 @@ PickColorWidget::PickColorWidget(DWidget *parent)
     });
 
     m_redEditLabel = new EditLabel(this);
+    m_redEditLabel->setObjectName("RedEditLabel");
+    m_redEditLabel->setAccessibleName("RedEditLabel");
 
     m_greenEditLabel = new EditLabel(this);
+    m_greenEditLabel->setObjectName("GreenEditLabel");
+    m_greenEditLabel->setAccessibleName("GreenEditLabel");
 
     m_blueEditLabel = new EditLabel(this);
+    m_blueEditLabel->setObjectName("BlueEditLabel");
+    m_blueEditLabel->setAccessibleName("BlueEditLabel");
 
     QMap<int, QMap<CIconButton::EIconButtonSattus, QString>> pictureMap;
 
     //取色器使用系统托管icon方式设置图标
     m_picker = new CIconButton(pictureMap, QSize(55, 36), this, false);
+    m_picker->setObjectName("PickColorPickerButton");
+    m_picker->setAccessibleName("PickColorPickerButton");
     m_picker->setIconMode();
     m_picker->setIconSize(QSize(36, 36));
     m_picker->setIcon(QIcon::fromTheme("dorpper_normal"));
@@ -75,7 +84,11 @@ PickColorWidget::PickColorWidget(DWidget *parent)
     rgbLayout->addSpacing(10);
     rgbLayout->addWidget(m_picker);
     m_colorSlider = new ColorSlider(this);
+    m_colorSlider->setObjectName("ColorSlider");
+    m_colorSlider->setAccessibleName("ColorSlider");
     m_colorLabel = new ColorLabel(this);
+    m_colorLabel->setObjectName("ColorLabel");
+    m_colorLabel->setAccessibleName("ColorLabel");
     m_colorLabel->setFixedSize(PICKCOLOR_WIDGET_SIZE.width(), 136);
 
     connect(m_colorSlider, &ColorSlider::valueChanged, m_colorLabel, [ = ](int val) {

--- a/src/frame/cgraphicsview.cpp
+++ b/src/frame/cgraphicsview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -324,6 +324,7 @@ void PageView::initContextMenu()
 
     //CMenu enterEvent激活全部action
     m_layerMenu = new DMenu(tr("Layer"), this);
+    m_layerMenu->setAccessibleName("LayerMenu");
 
     m_cutAct = new QAction(tr("Cut"), this);
     m_contextMenu->addAction(m_cutAct);
@@ -429,6 +430,7 @@ void PageView::initContextMenu()
 
     // 右键菜单添加对齐方式
     m_alignMenu = new DMenu(tr("Align"), this);
+    m_alignMenu->setAccessibleName("AlignMenu");
     m_contextMenu->addMenu(m_alignMenu);
 
     m_itemsLeftAlign = new QAction(tr("Align left"), this); //左对齐
@@ -683,6 +685,7 @@ void PageView::initContextMenuConnection()
 void PageView::initTextContextMenu()
 {
     m_textMenu = new DMenu(this);
+    m_textMenu->setAccessibleName("TextMenu");
 
     m_textCutAction = new QAction(tr("Cut"), m_textMenu);
     m_textCopyAction = new QAction(tr("Copy"), m_textMenu);

--- a/src/frame/clefttoolbar.cpp
+++ b/src/frame/clefttoolbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -277,6 +277,7 @@ void DrawToolManager::initUI()
 void DrawToolManager::initDrawTools()
 {
     toolButtonGroup = new QButtonGroup(this);
+    toolButtonGroup->setObjectName("ToolButtonGroup");
     toolButtonGroup->setExclusive(true);
 
 #if (QT_VERSION_MAJOR == 5)

--- a/src/frame/cmultiptabbarwidget.cpp
+++ b/src/frame/cmultiptabbarwidget.cpp
@@ -144,6 +144,8 @@ QMenu *TabBarWgt::menu() const
     static QMenu *s_menu = nullptr;
     if (s_menu == nullptr) {
         s_menu = new QMenu(const_cast<TabBarWgt *>(this));
+        s_menu->setObjectName("TabBarMenu");
+        s_menu->setAccessibleName("TabBarMenu");
         QAction *actionA = new QAction(tr("Close tab"), s_menu);
         connect(actionA, &QAction::triggered, this, [ = ]() {
             emit const_cast<TabBarWgt *>(this)->tabCloseRequested(currentIndex());
@@ -188,6 +190,7 @@ void TabBarWgt::mousePressEvent(QMouseEvent *event)
 FileSelectDialog::FileSelectDialog(DrawBoard *parent): DFileDialog(parent)
 {
     this->setObjectName("DDFSaveDialog");
+    this->setAccessibleName("DDFSaveDialog");
 
     //设置文件对话框为保存模式
     this->setAcceptMode(QFileDialog::AcceptSave);

--- a/src/frame/mainwindow.cpp
+++ b/src/frame/mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -128,6 +128,7 @@ void MainWindow::initUI()
 
     //ESC快捷键功能
     m_quitMode = new QAction(this);
+    m_quitMode->setObjectName("QuitMode");
     m_quitMode->setShortcut(QKeySequence(Qt::Key_Escape));
     this->addAction(m_quitMode);
 

--- a/src/frame/toptoolbar.cpp
+++ b/src/frame/toptoolbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -158,9 +158,11 @@ void TopTilte::initComboBox()
 void TopTilte::initMenu()
 {
     m_mainMenu = new CMenu(this);
+    m_mainMenu->setAccessibleName("MainMenu");
 //    m_mainMenu->setFixedWidth(162);
 
     m_newAction = new QAction(tr("New"), this);
+    m_newAction->setObjectName("NewAction");
     m_newAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_N));
     m_mainMenu->addAction(m_newAction);
     this->addAction(m_newAction);
@@ -172,6 +174,7 @@ void TopTilte::initMenu()
     m_mainMenu->addSeparator();
 
     m_saveAction = new QAction(tr("Save"), this);
+    m_saveAction->setObjectName("SaveAction");
     m_saveAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_S));
     m_mainMenu->addAction(m_saveAction);
     this->addAction(m_saveAction);

--- a/src/widgets/colorlabel.cpp
+++ b/src/widgets/colorlabel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,6 +26,7 @@ ColorLabel::ColorLabel(DWidget *parent)
     , m_tipPoint(this->rect().center())
 {
     qDebug() << "Initializing ColorLabel";
+    this->setAccessibleName("ColorLabel");
     setMouseTracking(true);
     connect(this, &ColorLabel::clicked, this, [ = ] {
         if (m_picking && m_workToPick)

--- a/src/widgets/colorslider.cpp
+++ b/src/widgets/colorslider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@ ColorSlider::ColorSlider(QWidget *parent)
     : QSlider(parent)
 {
     qDebug() << "Initializing ColorSlider";
+    this->setAccessibleName("ColorSlider");
     setMinimum(0);
     setMaximum(359);
     setOrientation(Qt::Horizontal);

--- a/src/widgets/csidewidthwidget.cpp
+++ b/src/widgets/csidewidthwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,6 +76,7 @@ void CSideWidthWidget::initUI()
     m_layout = new QHBoxLayout(this);
     _textLabel = new DLabel(this);
     m_menuComboBox = new QComboBox(this);
+    m_menuComboBox->setAccessibleName("MenuComboBox");
     m_menuComboBox->setFocusPolicy(Qt::NoFocus);
     m_maskLable = new DLabel(m_menuComboBox);
     m_maskLable->setText("— —");

--- a/src/widgets/cspinbox.cpp
+++ b/src/widgets/cspinbox.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,6 +20,7 @@ CSpinBox::CSpinBox(DWidget *parent)
     : DSpinBox(parent)
 {
     qDebug() << "Initializing CSpinBox";
+    this->setAccessibleName("CSpinBox");
     setFocusPolicy(Qt::StrongFocus);
     if (Application::isTabletSystemEnvir()) {
         qDebug() << "Tablet environment detected, setting read-only mode";

--- a/src/widgets/ctextedit.cpp
+++ b/src/widgets/ctextedit.cpp
@@ -36,6 +36,7 @@ CTextEdit::CTextEdit(CGraphicsTextItem *item, QWidget *parent)
     , m_pItem(item)
 {
     qDebug() << "Initializing CTextEdit";
+    this->setAccessibleName("CTextEdit");
     //初始化字体
     connect(this, &CTextEdit::textChanged, this, &CTextEdit::onTextChanged);
 

--- a/src/widgets/dialog/cexportimagedialog.cpp
+++ b/src/widgets/dialog/cexportimagedialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -184,9 +184,13 @@ void CExportImageDialog::initUI()
 
     //add new path widget.
     m_pathEditor = new DLineEdit(this);
+    m_pathEditor->setObjectName("ExportPathEditor");
+    m_pathEditor->setAccessibleName("ExportPathEditor");
     m_pathEditor->setClearButtonEnabled(false);
     m_pathEditor->lineEdit()->setReadOnly(true);
     m_pathChosenButton = new PathActiveButton(this);
+    m_pathChosenButton->setObjectName("ExportPathChosenButton");
+    m_pathChosenButton->setAccessibleName("ExportPathChosenButton");
     m_pathChosenButton->setFixedWidth(40);
     m_pathChosenButton->setToolTip(tr("Select other directories"));
     connect(m_pathChosenButton, &PathActiveButton::clicked, this, [ = ]() {
@@ -503,8 +507,10 @@ void CExportImageDialog::CExportImageDialog_private::initSizeSettingLayoutUi(QFo
     lay1->setContentsMargins(0, 0, 0, 0);
     lay1->setSpacing(9);
     _radioRadioBtn = new QRadioButton(tr("Percentage"), contentWidget);
+    _radioRadioBtn->setAccessibleName("ExportPercentRadio");
     lay1->addWidget(_radioRadioBtn);
     auto spinBox = new CSpinBox(contentWidget);
+    spinBox->setAccessibleName("ExportSizeSpinBox");
     spinBox->setSpinRange(0, 999999);
     spinBox->lineEdit()->setValidator(new CIntValidator(0, 999999, spinBox));
     spinBox->setEnabledEmbedStyle(true);
@@ -516,6 +522,7 @@ void CExportImageDialog::CExportImageDialog_private::initSizeSettingLayoutUi(QFo
     lay1->addWidget(_precentStuff);
     lay1->addSpacing(25);
     _radioPiexlBtn = new QRadioButton(tr("Pixels"), contentWidget);
+    _radioPiexlBtn->setAccessibleName("ExportPixelRadio");
     lay1->addWidget(_radioPiexlBtn);
     fLayout->addRow(tr("Dimensions:"), lay1);
 

--- a/src/widgets/dialog/cprogressdialog.cpp
+++ b/src/widgets/dialog/cprogressdialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,7 @@ ProgressDialog::ProgressDialog(const QString &text, DWidget *parent)
     : DDialog(parent)
 {
     qDebug() << "Initializing ProgressDialog with text:" << text;
+    this->setAccessibleName("ProgressDialog");
     initUI();
     _titleLabel->setText(text);
 }

--- a/src/widgets/dialog/dialog.cpp
+++ b/src/widgets/dialog/dialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 
 MessageDlg::MessageDlg(DWidget *parent) : DDialog(parent)
 {
+    this->setAccessibleName("MessageDlg");
     setModal(true);
     setWordWrapMessage(true);
     setMinimumSize(403, 163);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,0 +1,354 @@
+version: '1.0'
+widgets:
+- name: Crop tool button
+  source_file: src/drawshape/drawTools/ccuttool.cpp
+  line: 80
+  variable: m_cutBtn
+- name: scene cut attribution widget
+  source_file: src/drawshape/drawTools/ccuttool.cpp
+  line: 118
+  variable: pCutWidget
+- name: Ellipse tool button
+  source_file: src/drawshape/drawTools/cellipsetool.cpp
+  line: 43
+  variable: m_roundBtn
+- name: Eraser tool button
+  source_file: src/drawshape/drawTools/cerasertool.cpp
+  line: 70
+  variable: m_eraserBtn
+- name: Line tool button
+  source_file: src/drawshape/drawTools/clinetool.cpp
+  line: 41
+  variable: m_lineBtn
+- name: Blur tool button
+  source_file: src/drawshape/drawTools/cmasicotool.cpp
+  line: 145
+  variable: m_blurBtn
+- name: Pencil tool button
+  source_file: src/drawshape/drawTools/cpentool.cpp
+  line: 65
+  variable: m_penBtn
+- name: Line start style combox
+  source_file: src/drawshape/drawTools/cpentool.cpp
+  line: 87
+  variable: pStreakStartComboBox
+- name: Line end style combox
+  source_file: src/drawshape/drawTools/cpentool.cpp
+  line: 121
+  variable: pStreakEndComboBox
+- name: Import tool button
+  source_file: src/drawshape/drawTools/cpicturetool.cpp
+  line: 54
+  variable: m_picBtn
+- name: Star tool button
+  source_file: src/drawshape/drawTools/cpolygonalstartool.cpp
+  line: 32
+  variable: m_starBtn
+- name: Polygon tool button
+  source_file: src/drawshape/drawTools/cpolygontool.cpp
+  line: 52
+  variable: m_polygonBtn
+- name: Rectangle tool button
+  source_file: src/drawshape/drawTools/crecttool.cpp
+  line: 54
+  variable: m_rectBtn
+- name: stroken color button
+  source_file: src/drawshape/drawTools/crecttool.cpp
+  line: 73
+  variable: penColor
+- name: fill color button
+  source_file: src/drawshape/drawTools/crecttool.cpp
+  line: 129
+  variable: fillColor
+- name: Select tool button
+  source_file: src/drawshape/drawTools/cselecttool.cpp
+  line: 80
+  variable: m_selectBtn
+- name: Text color button
+  source_file: src/drawshape/drawTools/ctexttool.cpp
+  line: 56
+  variable: fontColor
+- name: Text tool button
+  source_file: src/drawshape/drawTools/ctexttool.cpp
+  line: 83
+  variable: m_textBtn
+- name: Text font family comboBox
+  source_file: src/drawshape/drawTools/ctexttool.cpp
+  line: 344
+  variable: fontComboBox
+- name: Text font style comboBox
+  source_file: src/drawshape/drawTools/ctexttool.cpp
+  line: 409
+  variable: ftStyleComboBox
+- name: Triangle tool button
+  source_file: src/drawshape/drawTools/ctriangletool.cpp
+  line: 46
+  variable: m_triangleBtn
+- name: TextEditor
+  source_file: src/drawshape/drawItems/bzItems/cgraphicstextitem.cpp
+  line: 95
+  variable: m_pTextEdit
+- name: LayerMenu
+  source_file: src/frame/cgraphicsview.cpp
+  line: 327
+  variable: m_layerMenu
+- name: AlignMenu
+  source_file: src/frame/cgraphicsview.cpp
+  line: 433
+  variable: m_alignMenu
+- name: TextMenu
+  source_file: src/frame/cgraphicsview.cpp
+  line: 688
+  variable: m_textMenu
+- name: LeftTool bar
+  source_file: src/frame/clefttoolbar.cpp
+  line: 216
+  variable: this
+- name: MultipTabBarWidget
+  source_file: src/frame/cmultiptabbarwidget.cpp
+  line: 29
+  variable: this
+- name: DDFSaveDialog
+  source_file: src/frame/cmultiptabbarwidget.cpp
+  line: 191
+  variable: ''
+- name: MainWindow
+  source_file: src/frame/mainwindow.cpp
+  line: 94
+  variable: this
+- name: TopToolbar
+  source_file: src/frame/toptoolbar.cpp
+  line: 51
+  variable: this
+- name: ComAttrWidget
+  source_file: src/frame/toptoolbar.cpp
+  line: 75
+  variable: m_pAttriManaWgt
+- name: MainMenu
+  source_file: src/frame/toptoolbar.cpp
+  line: 161
+  variable: m_mainMenu
+- name: ColorPickWidget
+  source_file: src/frame/AttributesWidgets/ccolorpickwidget.cpp
+  line: 20
+  variable: this
+- name: BlurWidget
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 84
+  variable: ''
+- name: Blur type button
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 92
+  variable: m_blurBtn
+- name: Masic type button
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 105
+  variable: m_masicBtn
+- name: Width
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 136
+  variable: ''
+- name: BlurPenWidth
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 141
+  variable: ''
+- name: WidthLabel
+  source_file: src/frame/AttributesWidgets/private/blurwidget.cpp
+  line: 162
+  variable: ''
+- name: AlphaLabel
+  source_file: src/frame/AttributesWidgets/private/calphacontrolwidget.cpp
+  line: 58
+  variable: ''
+- name: Color Alpha slider
+  source_file: src/frame/AttributesWidgets/private/calphacontrolwidget.cpp
+  line: 70
+  variable: m_alphaSlider
+- name: AttrComboBox
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 286
+  variable: ''
+- name: AttrSpinBox
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 382
+  variable: ''
+- name: groupButton
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 470
+  variable: groupButton
+- name: unGroupButton
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 477
+  variable: unGroupButton
+- name: AttrGroupButton
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 518
+  variable: expGroupBtn
+- name: AttrUngroupButton
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 527
+  variable: expUnGroupBtn
+- name: _pExpWidget
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 752
+  variable: _pExpWidget
+- name: AttrExpandButton
+  source_file: src/frame/AttributesWidgets/private/cattributeitemwidget.cpp
+  line: 761
+  variable: _expBtn
+- name: Cut ratio(1:1) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 324
+  variable: m_scaleBtn1_1
+- name: Cut ratio(2:3) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 332
+  variable: m_scaleBtn2_3
+- name: Cut ratio(8:5) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 339
+  variable: m_scaleBtn8_5
+- name: Cut ratio(16:9) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 346
+  variable: m_scaleBtn16_9
+- name: Cut ratio(free) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 353
+  variable: m_freeBtn
+- name: Cut ratio(Original) pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 360
+  variable: m_originalBtn
+- name: Cut done pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 378
+  variable: m_doneBtn
+- name: Cut cancel pushbutton
+  source_file: src/frame/AttributesWidgets/private/ccutwidget.cpp
+  line: 385
+  variable: m_cancelBtn
+- name: CAlphaControlWidget
+  source_file: src/frame/AttributesWidgets/private/colorpanel.cpp
+  line: 155
+  variable: ''
+- name: ColorLineEdit
+  source_file: src/frame/AttributesWidgets/private/colorpanel.cpp
+  line: 170
+  variable: ''
+- name: ColorfulBtn
+  source_file: src/frame/AttributesWidgets/private/colorpanel.cpp
+  line: 197
+  variable: ''
+- name: PickColorWidget
+  source_file: src/frame/AttributesWidgets/private/colorpanel.cpp
+  line: 211
+  variable: ''
+- name: RedEditLabel
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 54
+  variable: ''
+- name: GreenEditLabel
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 58
+  variable: ''
+- name: BlueEditLabel
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 62
+  variable: ''
+- name: PickColorPickerButton
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 69
+  variable: ''
+- name: ColorSlider
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 88
+  variable: ''
+- name: ColorLabel
+  source_file: src/frame/AttributesWidgets/private/pickcolorwidget.cpp
+  line: 91
+  variable: ''
+- name: CSideWidthWidget
+  source_file: src/widgets/csidewidthwidget.cpp
+  line: 75
+  variable: this
+- name: MenuComboBox
+  source_file: src/widgets/csidewidthwidget.cpp
+  line: 79
+  variable: m_menuComboBox
+- name: CSpinBox
+  source_file: src/widgets/cspinbox.cpp
+  line: 25
+  variable: ''
+- name: CTextEdit
+  source_file: src/widgets/ctextedit.cpp
+  line: 40
+  variable: ''
+- name: Zoom Form
+  source_file: src/widgets/dzoommenucombobox.cpp
+  line: 288
+  variable: this
+- name: Zoom Menu button
+  source_file: src/widgets/dzoommenucombobox.cpp
+  line: 291
+  variable: m_btn
+- name: Zoom Menu
+  source_file: src/widgets/dzoommenucombobox.cpp
+  line: 293
+  variable: m_menu
+- name: Zoom increase button
+  source_file: src/widgets/dzoommenucombobox.cpp
+  line: 306
+  variable: m_increaseBtn
+- name: Zoom reduce button
+  source_file: src/widgets/dzoommenucombobox.cpp
+  line: 307
+  variable: m_reduceBtn
+- name: Notice cut info dialog
+  source_file: src/widgets/dialog/ccutdialog.cpp
+  line: 22
+  variable: this
+- name: Export dialog
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 142
+  variable: this
+- name: Export name line editor
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 160
+  variable: m_fileNameEdit
+- name: Export path comboBox
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 171
+  variable: m_savePathCombox
+- name: ExportPathEditor
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 188
+  variable: ''
+- name: ExportPathChosenButton
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 193
+  variable: ''
+- name: Export format comboBox
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 220
+  variable: m_formatCombox
+- name: Export quality slider
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 226
+  variable: m_qualitySlider
+- name: Export content widget
+  source_file: src/widgets/dialog/cexportimagedialog.cpp
+  line: 243
+  variable: contentWidget
+- name: ProgressDialog
+  source_file: src/widgets/dialog/cprogressdialog.cpp
+  line: 20
+  variable: ''
+- name: MessageDlg
+  source_file: src/widgets/dialog/dialog.cpp
+  line: 13
+  variable: ''
+- name: Notice save dialog
+  source_file: src/widgets/dialog/drawdialog.cpp
+  line: 23
+  variable: this


### PR DESCRIPTION
## Summary

Add AT-SPI accessible names for UI widgets across the application to improve accessibility support and enable automated testing via AT-SPI frameworks.

## Changes

- Add class-level `setWgtAccesibleName` for: CMenu, ColorLabel, ColorSlider, CSpinBox, CTextEdit, ToolButton, EditLabel, MessageDlg, ProgressDialog
- Add instance-level accessible names for child controls in: PickColorWidget, ColorPanel, BlurWidget, CAlphaControlWidget, CAttributeItemWidget
- Add names for menus: MainMenu, LayerMenu, AlignMenu, TextMenu
- Upgrade existing `setObjectName` to `setWgtAccesibleName` for proper AT-SPI support
- Add `expected_names.yaml` AT baseline
- Update copyright years to 2026

## Related

- Previous attempt: #221 (closed, not merged)
- Full report: See issue comment

## Summary by Sourcery

Add consistent AT-SPI accessible names and identifiers across widgets, menus, actions, and dialogs, and introduce a test baseline to support accessibility tooling and automated UI testing.

New Features:
- Introduce AT-SPI accessible names for core UI widgets and dialogs to improve assistive technology support.
- Add accessible naming for key menus and actions used in the main window, toolbars, and context menus.
- Provide an expected_names.yaml baseline mapping widgets to their AT-SPI accessible names for automated testing.

Enhancements:
- Standardize widget identification by replacing direct setObjectName usage with setWgtAccesibleName where appropriate.
- Assign object and accessible names to button groups and combo boxes involved in drawing tools and attribute controls.

Documentation:
- Update SPDX copyright years across modified source files to 2026.

Tests:
- Add AT-SPI accessibility expectations file under tests/at/spi for validating widget naming.