### PR TITLE
fix(ctexttool): select default text font from registered family names

### DIFF
--- a/src/drawshape/drawTools/ctexttool.cpp
+++ b/src/drawshape/drawTools/ctexttool.cpp
@@ -347,11 +347,28 @@ void CTextTool::initFontFamilyWidget(QComboBox *fontHeavy)
     fontComboBox->lineEdit()->setReadOnly(true);
     fontFamily->setComboBox(fontComboBox);
 
-    // 设置默认的字体类型为思源宋黑体，没有该字体则选择系统第一个默认字体
+    // 设置默认字体为思源黑体（Source Han Sans）。字体族名必须使用 QFontDatabase::families()
+    // 中实际注册的名称，不能用 tr() 翻译后再匹配——翻译后的名称（如"思源黑体 CN"）在系统中
+    // 可能不存在，会导致 contains() 失败而回退到 families().first()，显示为无意义的字体名
+    // （如"C059 [UKWN]"，见 BUG-373351）。不同版本/发行版下思源黑体的注册族名不同（新版为
+    // "思源黑体"，旧版为"思源黑体 CN"，Noto 打包为"Noto Sans CJK SC"），故按优先级逐个尝试。
     QFontDatabase fontbase;
-    QString sourceHumFont = QObject::tr("Source Han Sans CN");
-    if (!fontbase.families().contains(sourceHumFont)) {
-        qDebug() << "Source Han Sans CN font not found, using first available font";
+    const QStringList defaultFontCandidates {
+        QStringLiteral("思源黑体"),          // 新版 Source Han Sans 的中文族名
+        QStringLiteral("思源黑体 CN"),       // 旧版族名，兼容旧系统
+        QStringLiteral("Source Han Sans CN"),
+        QStringLiteral("Source Han Sans SC"),
+        QStringLiteral("Noto Sans CJK SC")    // 思源黑体的 Noto 命名
+    };
+    QString sourceHumFont;
+    for (const QString &candidate : defaultFontCandidates) {
+        if (fontbase.families().contains(candidate)) {
+            sourceHumFont = candidate;
+            break;
+        }
+    }
+    if (sourceHumFont.isEmpty()) {
+        qDebug() << "No preferred CJK font found, using first available font";
         sourceHumFont = fontbase.families().first();
     }
     drawBoard()->attributionWidget()->installComAttributeWgt(EFontFamily, fontFamily, sourceHumFont);


### PR DESCRIPTION
## 根因

画板新增文本框时，属性栏"字体"下拉框默认显示为乱码 `C059 [UKWN]`，而非中文字体名。

根因在 `src/drawshape/drawTools/ctexttool.cpp` 的 `CTextTool::initFontFamilyWidget()`：默认字体名用 `tr("Source Han Sans CN")`（中文环境翻译为"思源黑体 CN"）去 `QFontDatabase::families()` 匹配。但 deepin 25.2 上思源黑体的实际注册族名是 `思源黑体`（新版 Source Han Sans 采用 `SC` 后缀，已无 `CN` 后缀），匹配必然失败，于是回退到 `families().first()`——本机实测恰为 `C059 [UKWN]`，与 bug 截图完全一致。字体族名属于系统标识，本不应经 `tr()` 翻译后再匹配。

证据：用 Qt6 `QFontDatabase` 实测 `families().first()` = `C059 [UKWN]`；`contains("思源黑体 CN")`=false、`contains("思源黑体")`=true；`styles("思源黑体")`=Regular|Medium（与截图字重吻合）。

## 修复方案

去掉 `tr()`，改为按优先级在 `QFontDatabase::families()` 中查找实际存在的候选族名：`思源黑体` → `思源黑体 CN` → `Source Han Sans CN` → `Source Han Sans SC` → `Noto Sans CJK SC`，全部不命中再回退 `families().first()`。修复后默认命中 `思源黑体`，下拉框正常显示中文。改动仅限默认字体名选取逻辑（1 文件 +21/-4），不动字体读写 API、不新增测试。

## 改动安全评估

低风险。`initFontFamilyWidget` 为私有方法，无外部调用者（仅头文件声明 + 构造函数自调用）；修复不改签名、不删公开成员；候选列表保留旧名 `思源黑体 CN` 兼容旧系统；与历史 BUG91224（预览/还原）修复无冲突。

## Summary by Sourcery

Bug Fixes:
- Fix text tool default font showing as an unreadable system font by selecting a preferred CJK font family from registered names with sensible fallbacks.